### PR TITLE
H2를 설정합니다.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ subprojects {
 
     // 실행 모듈 목록
     val executableModules = listOf("eatngo-customer-api", "eatngo-store-owner-api")
-    val enableJarModules = listOf("swagger", "common-test")
+    val enableJarModules = listOf("common")
 
     if (name in executableModules) {
         // 실행 모듈: jar, bootJar, bootRun 모두 활성화
@@ -38,6 +38,16 @@ subprojects {
         tasks.withType<Jar> { enabled = false }
         tasks.withType<org.springframework.boot.gradle.tasks.bundling.BootJar> { enabled = false }
         tasks.withType<org.springframework.boot.gradle.tasks.run.BootRun> { enabled = false }
+    }
+    tasks.withType<JavaCompile>().configureEach {
+        sourceCompatibility = "21"
+        targetCompatibility = "21"
+    }
+
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        kotlinOptions {
+            jvmTarget = "21"
+        }
     }
 
     tasks.withType<Test> {

--- a/eatngo-common/logging/build.gradle.kts
+++ b/eatngo-common/logging/build.gradle.kts
@@ -1,4 +1,17 @@
+plugins {
+   id("org.springframework.boot")
+}
+
 dependencies {
    implementation("org.springframework.boot:spring-boot-starter-logging")
    implementation("net.logstash.logback:logstash-logback-encoder:7.3")
+}
+
+tasks.bootJar{
+   enabled = false
+}
+
+tasks.jar {
+   enabled = true
+   archiveFileName.set("${project.name}.jar")
 }

--- a/eatngo-common/p6spy/build.gradle.kts
+++ b/eatngo-common/p6spy/build.gradle.kts
@@ -7,3 +7,12 @@ dependencies {
     implementation ("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 }
+
+tasks.bootJar{
+    enabled = false
+}
+
+tasks.jar {
+    enabled = true
+    archiveFileName.set("${project.name}.jar")
+}

--- a/eatngo-common/swagger/build.gradle.kts
+++ b/eatngo-common/swagger/build.gradle.kts
@@ -7,3 +7,8 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")    // Swagger UI
     implementation("org.springdoc:springdoc-openapi-starter-common:2.8.5")       // Swagger 공통 기능
 }
+
+tasks.jar {
+    enabled = true
+    archiveFileName.set("${project.name}.jar")
+}

--- a/eatngo-customer-api/build.gradle.kts
+++ b/eatngo-customer-api/build.gradle.kts
@@ -28,4 +28,7 @@ dependencies {
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
     testImplementation("io.mockk:mockk:1.13.10")                        // mockk
     testImplementation("com.appmattus.fixture:fixture:1.2.0")           // Kotlin-fixture
+
+    // h2
+    runtimeOnly("com.h2database:h2")
 }

--- a/eatngo-customer-api/src/main/resources/application.yml
+++ b/eatngo-customer-api/src/main/resources/application.yml
@@ -4,6 +4,25 @@ server:
 spring:
   application:
     name: eatngo-customer-api
+  datasource:
+    # H2 메모리 DB를 PostgreSQL 모드로 실행
+    url: jdbc:h2:mem:eatngo;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE
+    username: sa
+    password: sa
+    driverClassName: org.h2.Driver
+  jpa:
+    open-in-view: false
+    # Hibernate가 PostgreSQL 방언을 사용하도록 설정
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+  h2:
+    console:
+      enabled: true
 
 springdoc:
   swagger-ui:
@@ -15,3 +34,8 @@ swagger:
   title: "EatNGo 사용자 API"
   description: "EatNGo 서비스의 사용자용 API 문서"
   version: "v1.0.0"
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace

--- a/eatngo-store-owner-api/build.gradle.kts
+++ b/eatngo-store-owner-api/build.gradle.kts
@@ -22,4 +22,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.mockk:mockk:1.13.10")                        // mockk
     testImplementation("com.appmattus.fixture:fixture:1.2.0")           // Kotlin-fixture
+
+    // h2
+    runtimeOnly("com.h2database:h2")
 }

--- a/eatngo-store-owner-api/src/main/resources/application.yml
+++ b/eatngo-store-owner-api/src/main/resources/application.yml
@@ -4,6 +4,25 @@ server:
 spring:
   application:
     name: eatngo-store-owner-api
+  datasource:
+    # H2 메모리 DB를 PostgreSQL 모드로 실행
+    url: jdbc:h2:mem:eatngo;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE
+    username: sa
+    password: sa
+    driverClassName: org.h2.Driver
+  jpa:
+    open-in-view: false
+    # Hibernate가 PostgreSQL 방언을 사용하도록 설정
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+  h2:
+    console:
+      enabled: true
 
 springdoc:
   swagger-ui:
@@ -15,3 +34,8 @@ swagger:
   title: "EatNGo 점주 API"
   description: "EatNGo 서비스의 점주용 API 문서"
   version: "v1.0.0"
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace


### PR DESCRIPTION
postgresql로 설정하였습니다.

gradlew clean build가 되지않아서 일부 수정했는데 문제있는 부분 있는지 확인 부탁드립니다.
해당 PR 통과 이후에 github action으로 테스트 자동화까지 추가할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
    - eatngo-customer-api 및 eatngo-store-owner-api 모듈에 H2 인메모리 데이터베이스가 런타임 전용으로 추가되었습니다.
    - 각 서비스의 설정 파일에 H2 데이터베이스 연결 및 JPA, Hibernate, SQL 로그 레벨, H2 콘솔 활성화 등 개발 및 테스트에 유용한 환경 구성이 반영되었습니다.

- **빌드/설정**
    - 여러 모듈에서 Spring Boot 실행 JAR 대신 일반 JAR 파일이 생성되도록 빌드 설정이 변경되었습니다.
    - 모든 서브프로젝트의 자바 및 코틀린 컴파일 타겟 버전이 21로 통일되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->