### PR TITLE
[feat] 신규 이미지 빌드하도록 ci 수정

### DIFF
--- a/.github/workflows/deploy-customer.yml
+++ b/.github/workflows/deploy-customer.yml
@@ -64,10 +64,30 @@ jobs:
             --push \
             .
 
+      - name: Register new ECS task definition
+        run: |
+          IMAGE_URI="$ECR_URI:latest"
+
+          aws ecs describe-task-definition \
+            --task-definition eatngo-customer-api \
+            --query "taskDefinition" \
+            --region $AWS_REGION > task-def.json
+
+          jq ".containerDefinitions[0].image |= \"$IMAGE_URI\"" task-def.json > task-def-customer.json
+
+          aws ecs register-task-definition \
+            --cli-input-json file://task-def-customer.json \
+            --region $AWS_REGION
+
       - name: Update ECS service
         run: |
+          REVISION=$(aws ecs describe-task-definition \
+            --task-definition eatngo-customer-api \
+            --query "taskDefinition.revision" \
+            --region $AWS_REGION --output text)
+
           aws ecs update-service \
             --cluster eatngo-cluster \
-            --service eatngo-customer-api-service \
+            --service eatngo-customer-api-service:$REVISION \
             --force-new-deployment \
             --region $AWS_REGION

--- a/.github/workflows/deploy-store-owner.yml
+++ b/.github/workflows/deploy-store-owner.yml
@@ -64,6 +64,21 @@ jobs:
             --push \
             .
 
+      - name: Register new ECS task definition
+        run: |
+          IMAGE_URI="$ECR_URI:latest"
+
+          aws ecs describe-task-definition \
+            --task-definition eatngo-store-owner-api \
+            --query "taskDefinition" \
+            --region $AWS_REGION > task-def.json
+
+          jq ".containerDefinitions[0].image |= \"$IMAGE_URI\"" task-def.json > task-def-store-owner.json
+
+          aws ecs register-task-definition \
+            --cli-input-json file://task-def-store-owner.json \
+            --region $AWS_REGION
+
       - name: Update ECS service
         run: |
           aws ecs update-service \

--- a/.gitignore
+++ b/.gitignore
@@ -174,4 +174,8 @@ gradle-app.setting
 # Java heap dump
 *.hprof
 
+### Custom
+task-def-customer.json
+task-def-store-owner.json
+
 # End of https://www.toptal.com/developers/gitignore/api/kotlin,macos,intellij+iml,gradle


### PR DESCRIPTION
## 🚀 PR 목적 (Goal)
<!-- 이 PR이 해결하려는 문제/목표를 한 문장으로 명확하게 작성해주세요. -->

- Github Action CI에서 이미지 교체 로직 수정

---

## ✨ 주요 변경 사항 (Changes)
<!--
- 코드/구조/의존성 등 핵심 변경점만 요약
- ex) 주문 생성 API 추가, User 도메인 리팩토링, 결제 모듈 외부 API 연동 등
-->
- GitHub Actions CI에서 ECS 서비스에 변경된 Docker 이미지를 정상 반영하도록 개선
- 기존에는 ECS 서비스가 태스크만 재시작하며 이미지가 갱신되지 않던 문제 해결
- ECS 태스크 정의(Task Definition)를 새로 등록하고 서비스에 적용하는 로직 추가

---

## 📝 상세 설명 (Description)
<!--
- 구현 방식, 고민한 점, 선택한 대안
- 기존과 달라진 동작, 예외 처리 등
- 리뷰어가 이해를 위해 미리 알면 좋은 내용
-->

기존 워크플로우에서는 Docker 이미지를 ECR에 latest 태그로 푸시한 뒤, aws ecs update-service --force-new-deployment 명령으로 ECS 태스크를 재시작하는 방식이었습니다. 하지만 ECS는 동일한 태스크 정의(Task Definition)를 재사용하기 때문에 실제로는 새로운 이미지를 적용하지 않고 기존 이미지를 반복 실행하는 문제가 있었습니다.

이를 해결하기 위해 다음과 같은 개선을 적용했습니다:
- 기존 태스크 정의를 기반으로 새 JSON 파일을 생성한 뒤, image 필드를 최신 ECR 이미지(latest)로 갱신
- 이를 사용해 register-task-definition 명령으로 새 태스크 정의 revision을 등록
- update-service 명령에 새 revision을 명시적으로 지정하여 이미지 변경이 반영되도록 개선


---

## #️⃣ 연관 이슈 (Linked Issues)
<!-- ex) #123, #456 -->

---

## 🛠️ 작업 내역 (What was done)
<!--
- 이번 PR에서 실제로 작업한 내용을 항목별로 정리
- UI/UX 변경, API 추가/수정, 테스트 코드 작성 등
- 이미지/스크린샷 첨부 가능
-->
- ECS 태스크 정의(task definition)를 describe 후, jq를 활용해 ECR 이미지 URI를 갱신하는 스크립트 추가
- aws ecs register-task-definition 명령으로 새로운 revision을 생성
- aws ecs update-service에서 해당 revision을 명시적으로 지정하도록 수정

---

### 📸 스크린샷/데모 (선택, Screenshots/Demo)
<!-- UI 변경, API 응답 예시 등 시각적 자료가 있다면 첨부 -->

---

## 💬 리뷰 포인트 (Review Points)
<!--
- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 궁금한 점, 네이밍/구현 관련 의견 요청 등
- ex) "이 함수 네이밍이 적절한지?", "트랜잭션 처리 방식이 괜찮은지?"
-->

---

## ✅ 체크리스트 (Check List)
- [ ] 테스트 코드 작성 및 통과
- [ ] 문서/주석 최신화
- [ ] 로컬 빌드 및 주요 기능 정상 동작 확인
- [ ] 기타(아래에 추가)

---

## 🗂️ 추가 참고 자료/컨텍스트 (Optional)
<!--
- 참고한 문서, 외부 레퍼런스, 관련 이슈/PR 링크 등
- 기타 전달하고 싶은 내용
-->