### PR TITLE
[CHORE] 매장 데이터 Insert 하면서 추가로 필요한 카테고리 add

### DIFF
--- a/eatngo-core/src/main/kotlin/com/eatngo/common/constant/StoreEnum.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/common/constant/StoreEnum.kt
@@ -70,11 +70,14 @@ object StoreEnum {
         val category: String,
     ) {
         BREAD("빵"),
+        BAKERY("베이커리"),
+        COFFEE("커피전문점"),
         DESSERT("디저트"),
         KOREAN("한식"),
         FRUIT("과일"),
         PIZZA("피자"),
         SALAD("샐러드"),
+        RICECAKE("떡")
         ;
 
         companion object {


### PR DESCRIPTION
## 🚀 PR 목적 (Goal)
[CHORE] 매장 데이터 Insert 하면서 추가로 필요한 카테고리 add

---

## ✨ 주요 변경 사항 (Changes)
- 매장 데이터를 추가하면서 추가로 필요한 StoreCategory 를 추가했습니다.
```
        BREAD("빵"),
        BAKERY("베이커리"),
        COFFEE("커피전문점"),
        DESSERT("디저트"),
        KOREAN("한식"),
        FRUIT("과일"),
        PIZZA("피자"),
        SALAD("샐러드"),
        RICECAKE("떡")
```

---

## 📝 상세 설명 (Description)
- 단순 enum 필드 추가
- 즉시 반영 필요한 내용으로 바로 Merge
