### PR TITLE
[FEATURE] 회원 탈퇴 처리 고도화

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension
+
 plugins {
     kotlin("jvm") version "1.9.22"
     kotlin("plugin.spring") version "1.9.22" apply false
@@ -19,6 +21,12 @@ subprojects {
     apply(plugin = "org.jetbrains.kotlin.plugin.spring")
     apply(plugin = "io.spring.dependency-management")
 
+
+    the<DependencyManagementExtension>().apply {
+        imports {
+            mavenBom("org.springframework.cloud:spring-cloud-dependencies:2024.0.1")
+        }
+    }
     // 실행 모듈 목록
     val executableModules = listOf("eatngo-customer-api", "eatngo-store-owner-api")
     val enableJarModules = listOf("common")

--- a/eatngo-auth/build.gradle.kts
+++ b/eatngo-auth/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
 
     implementation(project(":eatngo-infra"))
     implementation(project(":eatngo-core"))

--- a/eatngo-auth/src/main/kotlin/com/eatngo/auth/config/WebMvcConfig.kt
+++ b/eatngo-auth/src/main/kotlin/com/eatngo/auth/config/WebMvcConfig.kt
@@ -1,11 +1,15 @@
 package com.eatngo.auth.config
 
+import com.eatngo.auth.resolver.UserAccountIdArgumentResolver
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-class WebMvcConfig : WebMvcConfigurer {
+class WebMvcConfig(
+    private val userAccountIdArgumentResolver: UserAccountIdArgumentResolver
+) : WebMvcConfigurer {
     override fun addCorsMappings(registry: CorsRegistry) {
         registry
             .addMapping("/**")
@@ -22,5 +26,8 @@ class WebMvcConfig : WebMvcConfigurer {
             ).allowedMethods("*")
             .allowedHeaders("*")
             .allowCredentials(true)
+    }
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(userAccountIdArgumentResolver)
     }
 }

--- a/eatngo-auth/src/main/kotlin/com/eatngo/auth/event/UserDeletedEventListener.kt
+++ b/eatngo-auth/src/main/kotlin/com/eatngo/auth/event/UserDeletedEventListener.kt
@@ -4,17 +4,16 @@ import com.eatngo.oauth2.OAuth2Service
 import com.eatngo.user_account.event.UserDeletedEvent
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 
 @Component
-@Transactional
 class UserDeletedEventListener(
     private val oauth2Services: Set<OAuth2Service>,
 ) {
 
     @Async
-    @TransactionalEventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun onUserDeleted(event: UserDeletedEvent) {
         event.userAccount.oAuth2.forEach { oauth2 ->
             oauth2Services.find {

--- a/eatngo-auth/src/main/kotlin/com/eatngo/auth/event/UserDeletedEventListener.kt
+++ b/eatngo-auth/src/main/kotlin/com/eatngo/auth/event/UserDeletedEventListener.kt
@@ -1,0 +1,25 @@
+package com.eatngo.auth.event
+
+import com.eatngo.oauth2.OAuth2Service
+import com.eatngo.user_account.event.UserDeletedEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+@Transactional
+class UserDeletedEventListener(
+    private val oauth2Services: Set<OAuth2Service>,
+) {
+
+    @Async
+    @TransactionalEventListener
+    fun onUserDeleted(event: UserDeletedEvent) {
+        event.userAccount.oAuth2.forEach { oauth2 ->
+            oauth2Services.find {
+                it.supports(oauth2.provider)
+            }?.unlink(oauth2.accessToken)
+        }
+    }
+}

--- a/eatngo-auth/src/main/kotlin/com/eatngo/oauth2/CustomOAuth2UserService.kt
+++ b/eatngo-auth/src/main/kotlin/com/eatngo/oauth2/CustomOAuth2UserService.kt
@@ -3,7 +3,7 @@ package com.eatngo.oauth2
 import com.eatngo.auth.constants.AuthenticationConstants.PRINCIPAL_KEY
 import com.eatngo.user_account.domain.UserAccount
 import com.eatngo.user_account.infra.UserAccountPersistence
-import com.eatngo.user_account.oauth2.constants.Oauth2Provider
+import com.eatngo.user_account.oauth2.constants.OAuth2Provider
 import com.eatngo.user_account.oauth2.constants.Role
 import com.eatngo.user_account.oauth2.constants.Role.*
 import com.eatngo.user_account.oauth2.domain.UserAccountOAuth2
@@ -28,7 +28,7 @@ class CustomOAuth2UserService(
         val delegate = DefaultOAuth2UserService()
         val oAuth2User = delegate.loadUser(userRequest)
 
-        val provider = Oauth2Provider.valueOfIgnoreCase(userRequest.clientRegistration.registrationId)
+        val provider = OAuth2Provider.valueOfIgnoreCase(userRequest.clientRegistration.registrationId)
         val token = userRequest.accessToken
         val oAuth2: OAuth2 = handleOauth2Attributes(provider, oAuth2User, token)
 
@@ -81,11 +81,11 @@ class CustomOAuth2UserService(
         }.distinct()
 
     private fun handleOauth2Attributes(
-        provider: Oauth2Provider,
+        provider: OAuth2Provider,
         oAuth2User: OAuth2User,
         token: OAuth2AccessToken
     ) = when (provider) {
-        Oauth2Provider.KAKAO -> KakaoOAuth2(
+        OAuth2Provider.KAKAO -> KakaoOAuth2(
             oAuth2User.attributes, provider, token.tokenValue,
             token.expiresAt?.atZone(ZoneId.of("Asia/Seoul"))?.toLocalDateTime(),
             token.scopes.joinToString(",")

--- a/eatngo-auth/src/main/kotlin/com/eatngo/oauth2/KakaoOAuth2Service.kt
+++ b/eatngo-auth/src/main/kotlin/com/eatngo/oauth2/KakaoOAuth2Service.kt
@@ -1,0 +1,16 @@
+package com.eatngo.oauth2
+
+import com.eatngo.oauth2.client.KakaoOAuth2Client
+import com.eatngo.user_account.oauth2.constants.OAuth2Provider
+import org.springframework.stereotype.Component
+
+@Component
+class KakaoOAuth2Service(
+    private val kakaoOAuth2Client: KakaoOAuth2Client,
+) : OAuth2Service {
+    override fun supports(provider: OAuth2Provider) = provider == OAuth2Provider.KAKAO
+
+    override fun unlink(accessToken: String) {
+        kakaoOAuth2Client.unlink("Bearer $accessToken")
+    }
+}

--- a/eatngo-auth/src/main/kotlin/com/eatngo/oauth2/OAuth2Service.kt
+++ b/eatngo-auth/src/main/kotlin/com/eatngo/oauth2/OAuth2Service.kt
@@ -1,0 +1,12 @@
+package com.eatngo.oauth2
+
+import com.eatngo.user_account.oauth2.constants.OAuth2Provider
+
+interface OAuth2Service {
+
+    fun supports(provider: OAuth2Provider): Boolean
+
+    fun unlink(accessToken: String)
+
+
+}

--- a/eatngo-auth/src/main/kotlin/com/eatngo/oauth2/client/KakaoOAuth2Client.kt
+++ b/eatngo-auth/src/main/kotlin/com/eatngo/oauth2/client/KakaoOAuth2Client.kt
@@ -1,0 +1,20 @@
+package com.eatngo.oauth2.client
+
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
+
+@FeignClient(
+    name = "kakao-oauth2",
+    url = "\${oauth2.kakao.url}",
+)
+interface KakaoOAuth2Client {
+
+    @PostMapping(
+        path = ["/v1/user/unlink"],
+        consumes = ["application/x-www-form-urlencoded"]
+    )
+    fun unlink(
+        @RequestHeader("Authorization") accessToken: String,
+    )
+}

--- a/eatngo-auth/src/main/resources/auth-application.yml
+++ b/eatngo-auth/src/main/resources/auth-application.yml
@@ -21,4 +21,7 @@ spring:
             user-name-attribute: id
 jwt:
   secret: ${JWT_SECRET:YW5Zb3UtY2FuLXVzZS10aGlzLWtleS1mb3ItanVzdC10ZXN0aW5nIQ==}
-  # anYou-can-use-this-key-for-just-testing! Base64-encoded -> // TODO 교체 및 외부 주입
+
+oauth2:
+  kakao:
+    url: https://kapi.kakao.com

--- a/eatngo-core/src/main/kotlin/com/eatngo/customer/event/CustomerEvent.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/customer/event/CustomerEvent.kt
@@ -1,0 +1,3 @@
+package com.eatngo.customer.event
+
+data class CustomerDeletedEvent(val userId: Long)

--- a/eatngo-core/src/main/kotlin/com/eatngo/customer/event/CustomerEventListener.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/customer/event/CustomerEventListener.kt
@@ -6,18 +6,17 @@ import com.eatngo.user_account.oauth2.constants.Role
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 
 @Component
-@Transactional
 class CustomerEventListener(
     private val userAccountPersistence: UserAccountPersistence,
     private val applicationEventPublisher: ApplicationEventPublisher
 ) {
 
     @Async
-    @TransactionalEventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun onCustomerDeleted(event: CustomerDeletedEvent) {
         val userId = event.userId
         userAccountPersistence.findById(userId)?.let { userAccount ->

--- a/eatngo-core/src/main/kotlin/com/eatngo/customer/event/CustomerEventListener.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/customer/event/CustomerEventListener.kt
@@ -1,0 +1,37 @@
+package com.eatngo.customer.event
+
+import com.eatngo.user_account.event.UserDeletedEvent
+import com.eatngo.user_account.infra.UserAccountPersistence
+import com.eatngo.user_account.oauth2.constants.Role
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+@Transactional
+class CustomerEventListener(
+    private val userAccountPersistence: UserAccountPersistence,
+    private val applicationEventPublisher: ApplicationEventPublisher
+) {
+
+    @Async
+    @TransactionalEventListener
+    fun onCustomerDeleted(event: CustomerDeletedEvent) {
+        val userId = event.userId
+        userAccountPersistence.findById(userId)?.let { userAccount ->
+            if (userAccount.roles.isEmpty()) {
+                userAccountPersistence.deleteById(userId)
+                applicationEventPublisher.publishEvent(
+                    UserDeletedEvent(userAccount)
+                )
+            } else {
+                userAccount.roles.find { it.role == Role.CUSTOMER }?.let {
+                    userAccount.roles.remove(it)
+                }
+                userAccountPersistence.save(userAccount)
+            }
+        }
+    }
+}

--- a/eatngo-core/src/main/kotlin/com/eatngo/customer/event/CustomerEventListener.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/customer/event/CustomerEventListener.kt
@@ -20,16 +20,17 @@ class CustomerEventListener(
     fun onCustomerDeleted(event: CustomerDeletedEvent) {
         val userId = event.userId
         userAccountPersistence.findById(userId)?.let { userAccount ->
-            if (userAccount.roles.isEmpty()) {
+            val roles = userAccount.roles
+            roles.find { it.role == Role.CUSTOMER }?.let {
+                roles.remove(it)
+            }
+            userAccountPersistence.save(userAccount)
+
+            if (roles.isEmpty()) {
                 userAccountPersistence.deleteById(userId)
                 applicationEventPublisher.publishEvent(
                     UserDeletedEvent(userAccount)
                 )
-            } else {
-                userAccount.roles.find { it.role == Role.CUSTOMER }?.let {
-                    userAccount.roles.remove(it)
-                }
-                userAccountPersistence.save(userAccount)
             }
         }
     }

--- a/eatngo-core/src/main/kotlin/com/eatngo/customer/service/CustomerService.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/customer/service/CustomerService.kt
@@ -3,9 +3,9 @@ package com.eatngo.customer.service
 import com.eatngo.common.exception.user.CustomerException
 import com.eatngo.customer.domain.Customer
 import com.eatngo.customer.dto.CustomerUpdateDto
+import com.eatngo.customer.event.CustomerDeletedEvent
 import com.eatngo.customer.infra.CustomerPersistence
 import com.eatngo.user_account.domain.UserAccount
-import com.eatngo.user_account.event.CustomerDeleted
 import com.eatngo.user_account.infra.UserAccountPersistence
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
@@ -24,7 +24,7 @@ class CustomerService(
     fun deleteCustomer(id: Long) {
         customerPersistence.deleteById(id)
         applicationEventPublisher.publishEvent(
-            CustomerDeleted(id)
+            CustomerDeletedEvent(id)
         )
     }
 

--- a/eatngo-core/src/main/kotlin/com/eatngo/customer/service/CustomerService.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/customer/service/CustomerService.kt
@@ -5,13 +5,16 @@ import com.eatngo.customer.domain.Customer
 import com.eatngo.customer.dto.CustomerUpdateDto
 import com.eatngo.customer.infra.CustomerPersistence
 import com.eatngo.user_account.domain.UserAccount
+import com.eatngo.user_account.event.CustomerDeleted
 import com.eatngo.user_account.infra.UserAccountPersistence
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 
 @Service
 class CustomerService(
     private val userAccountPersistence: UserAccountPersistence,
     private val customerPersistence: CustomerPersistence,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) {
 
     fun getCustomerById(id: Long): Customer {
@@ -20,7 +23,9 @@ class CustomerService(
 
     fun deleteCustomer(id: Long) {
         customerPersistence.deleteById(id)
-        userAccountPersistence.deleteById(id)
+        applicationEventPublisher.publishEvent(
+            CustomerDeleted(id)
+        )
     }
 
     fun update(customerId: Long, customerUpdateDto: CustomerUpdateDto) {

--- a/eatngo-core/src/main/kotlin/com/eatngo/store_owner/event/StoreOwnerEvent.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/store_owner/event/StoreOwnerEvent.kt
@@ -1,0 +1,3 @@
+package com.eatngo.customer.event
+
+data class StoreOwnerDeletedEvent(val userId: Long)

--- a/eatngo-core/src/main/kotlin/com/eatngo/store_owner/event/StoreOwnerEventListener.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/store_owner/event/StoreOwnerEventListener.kt
@@ -20,16 +20,16 @@ class StoreOwnerEventListener(
     fun onCustomerDeleted(event: StoreOwnerDeletedEvent) {
         val userId = event.userId
         userAccountPersistence.findById(userId)?.let { userAccount ->
+            userAccount.roles.find { it.role == Role.STORE_OWNER }?.let {
+                userAccount.roles.remove(it)
+            }
+            userAccountPersistence.save(userAccount)
+
             if (userAccount.roles.isEmpty()) {
                 userAccountPersistence.deleteById(userId)
                 applicationEventPublisher.publishEvent(
                     UserDeletedEvent(userAccount)
                 )
-            } else {
-                userAccount.roles.find { it.role == Role.STORE_OWNER }?.let {
-                    userAccount.roles.remove(it)
-                }
-                userAccountPersistence.save(userAccount)
             }
         }
     }

--- a/eatngo-core/src/main/kotlin/com/eatngo/store_owner/event/StoreOwnerEventListener.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/store_owner/event/StoreOwnerEventListener.kt
@@ -6,18 +6,17 @@ import com.eatngo.user_account.oauth2.constants.Role
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 
 @Component
-@Transactional
 class StoreOwnerEventListener(
     private val userAccountPersistence: UserAccountPersistence,
     private val applicationEventPublisher: ApplicationEventPublisher
 ) {
 
     @Async
-    @TransactionalEventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun onCustomerDeleted(event: StoreOwnerDeletedEvent) {
         val userId = event.userId
         userAccountPersistence.findById(userId)?.let { userAccount ->

--- a/eatngo-core/src/main/kotlin/com/eatngo/store_owner/event/StoreOwnerEventListener.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/store_owner/event/StoreOwnerEventListener.kt
@@ -1,0 +1,37 @@
+package com.eatngo.customer.event
+
+import com.eatngo.user_account.event.UserDeletedEvent
+import com.eatngo.user_account.infra.UserAccountPersistence
+import com.eatngo.user_account.oauth2.constants.Role
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+@Transactional
+class StoreOwnerEventListener(
+    private val userAccountPersistence: UserAccountPersistence,
+    private val applicationEventPublisher: ApplicationEventPublisher
+) {
+
+    @Async
+    @TransactionalEventListener
+    fun onCustomerDeleted(event: StoreOwnerDeletedEvent) {
+        val userId = event.userId
+        userAccountPersistence.findById(userId)?.let { userAccount ->
+            if (userAccount.roles.isEmpty()) {
+                userAccountPersistence.deleteById(userId)
+                applicationEventPublisher.publishEvent(
+                    UserDeletedEvent(userAccount)
+                )
+            } else {
+                userAccount.roles.find { it.role == Role.STORE_OWNER }?.let {
+                    userAccount.roles.remove(it)
+                }
+                userAccountPersistence.save(userAccount)
+            }
+        }
+    }
+}

--- a/eatngo-core/src/main/kotlin/com/eatngo/store_owner/service/StoreOwnerService.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/store_owner/service/StoreOwnerService.kt
@@ -1,11 +1,11 @@
 package com.eatngo.store_owner.service
 
 import com.eatngo.common.exception.store.StoreException
+import com.eatngo.customer.event.StoreOwnerDeletedEvent
 import com.eatngo.store_owner.domain.StoreOwner
 import com.eatngo.store_owner.dto.StoreOwnerUpdateDto
 import com.eatngo.store_owner.infra.StoreOwnerPersistence
 import com.eatngo.user_account.domain.UserAccount
-import com.eatngo.user_account.event.StoreOwnerDeleted
 import com.eatngo.user_account.infra.UserAccountPersistence
 import org.springframework.stereotype.Service
 
@@ -23,7 +23,7 @@ class StoreOwnerService(
     fun deleteStoreOwner(id: Long) {
         storeOwnerPersistence.deleteById(id)
         applicationEventPublisher.publishEvent(
-            StoreOwnerDeleted(id)
+            StoreOwnerDeletedEvent(id)
         )
     }
 

--- a/eatngo-core/src/main/kotlin/com/eatngo/store_owner/service/StoreOwnerService.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/store_owner/service/StoreOwnerService.kt
@@ -23,13 +23,13 @@ class StoreOwnerService(
         userAccountPersistence.deleteById(id)
     }
 
-    fun update(StoreOwnerId: Long, StoreOwnerUpdateDto: StoreOwnerUpdateDto) {
-        val storeOwner = storeOwnerPersistence.getByIdOrThrow(StoreOwnerId)
-        storeOwner.update(StoreOwnerUpdateDto)
+    fun update(storeOwnerId: Long, storeOwnerUpdateDto: StoreOwnerUpdateDto) {
+        val storeOwner = storeOwnerPersistence.getByIdOrThrow(storeOwnerId)
+        storeOwner.update(storeOwnerUpdateDto)
         storeOwnerPersistence.save(storeOwner)
 
         val account = userAccountPersistence.getByIdOrThrow(storeOwner.account.id)
-        account.update(StoreOwnerUpdateDto)
+        account.update(storeOwnerUpdateDto)
         userAccountPersistence.save(account)
     }
 

--- a/eatngo-core/src/main/kotlin/com/eatngo/store_owner/service/StoreOwnerService.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/store_owner/service/StoreOwnerService.kt
@@ -5,13 +5,15 @@ import com.eatngo.store_owner.domain.StoreOwner
 import com.eatngo.store_owner.dto.StoreOwnerUpdateDto
 import com.eatngo.store_owner.infra.StoreOwnerPersistence
 import com.eatngo.user_account.domain.UserAccount
+import com.eatngo.user_account.event.StoreOwnerDeleted
 import com.eatngo.user_account.infra.UserAccountPersistence
 import org.springframework.stereotype.Service
 
 @Service
 class StoreOwnerService(
     private val userAccountPersistence: UserAccountPersistence,
-    private val storeOwnerPersistence: StoreOwnerPersistence
+    private val storeOwnerPersistence: StoreOwnerPersistence,
+    private val applicationEventPublisher: org.springframework.context.ApplicationEventPublisher
 ) {
 
     fun getStoreOwnerById(id: Long): StoreOwner {
@@ -20,7 +22,9 @@ class StoreOwnerService(
 
     fun deleteStoreOwner(id: Long) {
         storeOwnerPersistence.deleteById(id)
-        userAccountPersistence.deleteById(id)
+        applicationEventPublisher.publishEvent(
+            StoreOwnerDeleted(id)
+        )
     }
 
     fun update(storeOwnerId: Long, storeOwnerUpdateDto: StoreOwnerUpdateDto) {

--- a/eatngo-core/src/main/kotlin/com/eatngo/user_account/domain/UserAccount.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/user_account/domain/UserAccount.kt
@@ -12,7 +12,7 @@ class UserAccount(
     val id: Long = 0,
     val email: EmailAddress?,
     var nickname: Nickname? = null,
-    var roles: List<UserRole> = mutableListOf(),
+    var roles: MutableSet<UserRole> = mutableSetOf(),
     val createdAt: LocalDateTime? = null,
     var updatedAt: LocalDateTime? = null,
     var deletedAt: LocalDateTime? = null,
@@ -46,7 +46,7 @@ class UserAccount(
                     oAuth2 = oAuth2
                 )
             )
-            userAccount.roles = listOf(UserRole(null, Role.USER))
+            userAccount.roles = mutableSetOf(UserRole(null, Role.USER))
 
             return userAccount
         }

--- a/eatngo-core/src/main/kotlin/com/eatngo/user_account/event/UserDeletedEvent.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/user_account/event/UserDeletedEvent.kt
@@ -1,0 +1,7 @@
+package com.eatngo.user_account.event
+
+import com.eatngo.user_account.domain.UserAccount
+
+data class UserDeletedEvent(
+    val userAccount: UserAccount
+)

--- a/eatngo-core/src/main/kotlin/com/eatngo/user_account/infra/UserAccountPersistence.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/user_account/infra/UserAccountPersistence.kt
@@ -2,7 +2,7 @@ package com.eatngo.user_account.infra
 
 import com.eatngo.common.exception.user.UserAccountException
 import com.eatngo.user_account.domain.UserAccount
-import com.eatngo.user_account.oauth2.constants.Oauth2Provider
+import com.eatngo.user_account.oauth2.constants.OAuth2Provider
 import com.eatngo.user_account.vo.EmailAddress
 
 interface UserAccountPersistence {
@@ -14,6 +14,6 @@ interface UserAccountPersistence {
 
     fun findById(id: Long): UserAccount?
     fun deleteById(id: Long)
-    fun findByOauth(userKey: String, provider: Oauth2Provider): UserAccount?
+    fun findByOauth(userKey: String, provider: OAuth2Provider): UserAccount?
     fun findByEmail(emailAddress: EmailAddress): UserAccount?
 }

--- a/eatngo-core/src/main/kotlin/com/eatngo/user_account/oauth2/constants/OAuth2Provider.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/user_account/oauth2/constants/OAuth2Provider.kt
@@ -1,6 +1,6 @@
 package com.eatngo.user_account.oauth2.constants
 
-enum class Oauth2Provider {
+enum class OAuth2Provider {
     KAKAO;
 
 

--- a/eatngo-core/src/main/kotlin/com/eatngo/user_account/oauth2/domain/UserAccountOAuth2.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/user_account/oauth2/domain/UserAccountOAuth2.kt
@@ -1,7 +1,7 @@
 package com.eatngo.user_account.oauth2.domain
 
 import com.eatngo.user_account.domain.UserAccount
-import com.eatngo.user_account.oauth2.constants.Oauth2Provider
+import com.eatngo.user_account.oauth2.constants.OAuth2Provider
 import com.eatngo.user_account.oauth2.dto.OAuth2
 import com.eatngo.user_account.vo.EmailAddress
 import java.time.LocalDateTime
@@ -11,9 +11,9 @@ class UserAccountOAuth2(
     val userAccount: UserAccount,
     val email: EmailAddress?,
     var nickname: String? = null,
-    var provider: Oauth2Provider,
+    var provider: OAuth2Provider,
     var userKey: String,
-    var accessToken: String? = null,
+    var accessToken: String,
     var expireAt: LocalDateTime? = null,
     var scopes: String? = null,
     val createdAt: LocalDateTime? = null,

--- a/eatngo-core/src/main/kotlin/com/eatngo/user_account/oauth2/dto/KakaoOAuth2.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/user_account/oauth2/dto/KakaoOAuth2.kt
@@ -1,12 +1,12 @@
 package com.eatngo.user_account.oauth2.dto
 
-import com.eatngo.user_account.oauth2.constants.Oauth2Provider
+import com.eatngo.user_account.oauth2.constants.OAuth2Provider
 import java.time.LocalDateTime
 
 
 data class KakaoOAuth2(
     private val attributes: Map<String, Any>,
-    override val provider: Oauth2Provider,
+    override val provider: OAuth2Provider,
     override val token: String,
     override val expiresAt: LocalDateTime? = null,
     override val scopes: String,
@@ -19,5 +19,5 @@ data class KakaoOAuth2(
     override val email: String? = kakaoAccount["email"] as? String
     override val nickname: String? = profile["nickname"] as? String
     override val principal: String = id.toString()
-    override val terms: List<OauthTerm> = emptyList()
+    override val terms: List<OAuthTerm> = emptyList()
 }

--- a/eatngo-core/src/main/kotlin/com/eatngo/user_account/oauth2/dto/OAuth2.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/user_account/oauth2/dto/OAuth2.kt
@@ -1,14 +1,14 @@
 package com.eatngo.user_account.oauth2.dto
 
-import com.eatngo.user_account.oauth2.constants.Oauth2Provider
+import com.eatngo.user_account.oauth2.constants.OAuth2Provider
 import java.time.LocalDateTime
 
 interface OAuth2 {
 
     val id: Long
     val email: String?
-    val provider: Oauth2Provider
-    val terms: List<OauthTerm>
+    val provider: OAuth2Provider
+    val terms: List<OAuthTerm>
     val principal: String
     val nickname: String?
     val token: String

--- a/eatngo-core/src/main/kotlin/com/eatngo/user_account/oauth2/dto/OAuthTerm.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/user_account/oauth2/dto/OAuthTerm.kt
@@ -2,7 +2,7 @@ package com.eatngo.user_account.oauth2.dto
 
 import java.time.LocalDateTime
 
-data class OauthTerm(
+data class OAuthTerm(
     val tag: String,
     val agreedAt: LocalDateTime,
 )

--- a/eatngo-customer-api/build.gradle.kts
+++ b/eatngo-customer-api/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security") // Spring Security 지원
     implementation("org.jetbrains.kotlin:kotlin-reflect")              // Kotlin 리플렉션 지원
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin") // Kotlin JSON 직렬화/역직렬화
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
 
     // API 문서화
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")    // Swagger UI

--- a/eatngo-customer-api/src/main/kotlin/com/eatngo/CustomerApplication.kt
+++ b/eatngo-customer-api/src/main/kotlin/com/eatngo/CustomerApplication.kt
@@ -3,9 +3,11 @@ package com.eatngo
 import com.eatngo.swagger.SwaggerConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.context.annotation.Import
 
 @Import(SwaggerConfig::class)
+@EnableFeignClients(basePackages = ["com.eatngo.oauth2.client"])
 @SpringBootApplication
 class CustomerApplication
 

--- a/eatngo-customer-api/src/main/kotlin/com/eatngo/auth/OAuth2DocController.kt
+++ b/eatngo-customer-api/src/main/kotlin/com/eatngo/auth/OAuth2DocController.kt
@@ -1,6 +1,6 @@
 package com.eatngo.auth
 
-import com.eatngo.user_account.oauth2.constants.Oauth2Provider
+import com.eatngo.user_account.oauth2.constants.OAuth2Provider
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.headers.Header
@@ -44,7 +44,7 @@ class OAuth2DocController {
             example = "KAKAO",
             required = true
         )
-        @PathVariable provider: Oauth2Provider = Oauth2Provider.KAKAO
+        @PathVariable provider: OAuth2Provider = OAuth2Provider.KAKAO
     ) {
         // 실제 리디렉션은 Spring Security가 수행하므로 여기는 비어 있음
     }

--- a/eatngo-customer-api/src/main/kotlin/com/eatngo/config/WebConfig.kt
+++ b/eatngo-customer-api/src/main/kotlin/com/eatngo/config/WebConfig.kt
@@ -1,0 +1,16 @@
+package com.eatngo.config
+
+import com.eatngo.auth.resolver.CustomerIdArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig(
+    private val customerIdArgumentResolver: CustomerIdArgumentResolver
+) : WebMvcConfigurer {
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(customerIdArgumentResolver)
+    }
+}

--- a/eatngo-customer-api/src/main/kotlin/com/eatngo/customer/CustomerController.kt
+++ b/eatngo-customer-api/src/main/kotlin/com/eatngo/customer/CustomerController.kt
@@ -5,7 +5,6 @@ import com.eatngo.common.response.ApiResponse
 import com.eatngo.customer.dto.CustomerDto
 import com.eatngo.customer.dto.CustomerUpdateDto
 import com.eatngo.customer.service.CustomerService
-import com.eatngo.oauth2.OAuth2Service
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
@@ -16,7 +15,6 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/v1/customers")
 class CustomerController(
     private val customerService: CustomerService,
-    private val oAuth2Service: Set<OAuth2Service>
 ) {
     @Operation(summary = "고객 정보 조회 API", description = "고객 정보를 조회하는 API")
     @GetMapping("/me")
@@ -33,13 +31,7 @@ class CustomerController(
     fun deleteCustomer(
         @CustomerId customerId: Long,
     ): ResponseEntity<Unit> {
-        val customer = customerService.getCustomerById(customerId)
         customerService.deleteCustomer(customerId)
-        customer.account.oAuth2.forEach { oauth2 ->
-            oAuth2Service.find {
-                it.supports(oauth2.provider)
-            }?.unlink(oauth2.accessToken)
-        }
         return ResponseEntity.noContent().build()
     }
 

--- a/eatngo-customer-api/src/test/kotlin/com/eatngo/helper/CustomerTestHelper.kt
+++ b/eatngo-customer-api/src/test/kotlin/com/eatngo/helper/CustomerTestHelper.kt
@@ -4,7 +4,7 @@ import com.eatngo.auth.dto.LoginCustomer
 import com.eatngo.auth.token.TokenProvider
 import com.eatngo.customer.service.CustomerAddressService
 import com.eatngo.customer.service.CustomerService
-import com.eatngo.user_account.oauth2.constants.Oauth2Provider
+import com.eatngo.user_account.oauth2.constants.OAuth2Provider
 import com.eatngo.user_account.oauth2.dto.KakaoOAuth2
 import com.eatngo.user_account.service.UserAccountService
 import org.springframework.boot.test.context.TestComponent
@@ -26,7 +26,7 @@ class CustomerTestHelper(
                         "profile" to mapOf("nickname" to "홍길동")
                     )
                 ),
-                Oauth2Provider.KAKAO,
+                OAuth2Provider.KAKAO,
                 "token",
                 expiresAt = java.time.LocalDateTime.now().plusDays(1),
                 scopes = "profile,email"

--- a/eatngo-infra/src/main/kotlin/com/eatngo/user_account/persistence/UserAccountPersistenceImpl.kt
+++ b/eatngo-infra/src/main/kotlin/com/eatngo/user_account/persistence/UserAccountPersistenceImpl.kt
@@ -3,7 +3,7 @@ package com.eatngo.user_account.persistence
 import com.eatngo.aop.SoftDeletedFilter
 import com.eatngo.user_account.domain.UserAccount
 import com.eatngo.user_account.infra.UserAccountPersistence
-import com.eatngo.user_account.oauth2.constants.Oauth2Provider
+import com.eatngo.user_account.oauth2.constants.OAuth2Provider
 import com.eatngo.user_account.rdb.entity.UserAccountJpaEntity
 import com.eatngo.user_account.rdb.repository.UserAccountRdbRepository
 import com.eatngo.user_account.vo.EmailAddress
@@ -36,7 +36,7 @@ class UserAccountPersistenceImpl(
     }
 
     @SoftDeletedFilter
-    override fun findByOauth(userKey: String, provider: Oauth2Provider) =
+    override fun findByOauth(userKey: String, provider: OAuth2Provider) =
         userAccountRdbRepository.findByOAuth2Key(userKey, provider)
             ?.let { UserAccountJpaEntity.toUserAccount(it) }
 

--- a/eatngo-infra/src/main/kotlin/com/eatngo/user_account/rdb/entity/UserAccountJpaEntity.kt
+++ b/eatngo-infra/src/main/kotlin/com/eatngo/user_account/rdb/entity/UserAccountJpaEntity.kt
@@ -53,7 +53,7 @@ class UserAccountJpaEntity(
                 createdAt = createdAt,
                 updatedAt = updatedAt,
                 deletedAt = deletedAt,
-                roles = roles.map { UserAccountRoleJpaEntity.toRole(it) },
+                roles = roles.map { UserAccountRoleJpaEntity.toRole(it) }.toMutableSet(),
             )
             account.oAuth2.forEach {
                 userAccount.addOauth2(

--- a/eatngo-infra/src/main/kotlin/com/eatngo/user_account/rdb/entity/UserAccountOAuth2JpaEntity.kt
+++ b/eatngo-infra/src/main/kotlin/com/eatngo/user_account/rdb/entity/UserAccountOAuth2JpaEntity.kt
@@ -3,7 +3,7 @@ package com.eatngo.user_account.rdb.entity
 import com.eatngo.common.BaseJpaEntity
 import com.eatngo.constants.DELETED_FILTER
 import com.eatngo.user_account.domain.UserAccount
-import com.eatngo.user_account.oauth2.constants.Oauth2Provider
+import com.eatngo.user_account.oauth2.constants.OAuth2Provider
 import com.eatngo.user_account.oauth2.domain.UserAccountOAuth2
 import com.eatngo.user_account.vo.EmailAddress
 import com.eatngo.user_account.vo.Nickname
@@ -38,13 +38,13 @@ class UserAccountOAuth2JpaEntity(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    val provider: Oauth2Provider,
+    val provider: OAuth2Provider,
 
     @Column(nullable = false, length = 255)
     val userKey: String,
 
     @Column(columnDefinition = "TEXT")
-    val accessToken: String? = null,
+    val accessToken: String,
 
     val expireAt: LocalDateTime? = null,
 

--- a/eatngo-infra/src/main/kotlin/com/eatngo/user_account/rdb/repository/UserAccountRdbRepository.kt
+++ b/eatngo-infra/src/main/kotlin/com/eatngo/user_account/rdb/repository/UserAccountRdbRepository.kt
@@ -1,6 +1,6 @@
 package com.eatngo.user_account.rdb.repository
 
-import com.eatngo.user_account.oauth2.constants.Oauth2Provider
+import com.eatngo.user_account.oauth2.constants.OAuth2Provider
 import com.eatngo.user_account.rdb.entity.UserAccountJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -27,7 +27,7 @@ interface UserAccountRdbRepository : JpaRepository<UserAccountJpaEntity, Long> {
         AND o2.userKey = :userKey
     """
     )
-    fun findByOAuth2Key(userKey: String, provider: Oauth2Provider): UserAccountJpaEntity?
+    fun findByOAuth2Key(userKey: String, provider: OAuth2Provider): UserAccountJpaEntity?
 
     @Query(
         """

--- a/eatngo-store-owner-api/build.gradle.kts
+++ b/eatngo-store-owner-api/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security") // Spring Security 지원
     implementation("org.jetbrains.kotlin:kotlin-reflect") // Kotlin 리플렉션 지원
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin") // Kotlin JSON 직렬화/역직렬화
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
 
     // API 문서화
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5") // Swagger UI

--- a/eatngo-store-owner-api/src/main/kotlin/com/eatngo/StoreOwnerApplication.kt
+++ b/eatngo-store-owner-api/src/main/kotlin/com/eatngo/StoreOwnerApplication.kt
@@ -3,11 +3,13 @@ package com.eatngo
 import com.eatngo.swagger.SwaggerConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.context.annotation.Import
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @Import(SwaggerConfig::class)
 @EnableScheduling
+@EnableFeignClients(basePackages = ["com.eatngo.oauth2.client"])
 @SpringBootApplication
 class StoreOwnerApplication
 

--- a/eatngo-store-owner-api/src/main/kotlin/com/eatngo/auth/OAuth2DocController.kt
+++ b/eatngo-store-owner-api/src/main/kotlin/com/eatngo/auth/OAuth2DocController.kt
@@ -1,6 +1,6 @@
 package com.eatngo.auth
 
-import com.eatngo.user_account.oauth2.constants.Oauth2Provider
+import com.eatngo.user_account.oauth2.constants.OAuth2Provider
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.headers.Header
@@ -44,7 +44,7 @@ class OAuth2DocController {
             example = "KAKAO",
             required = true
         )
-        @PathVariable provider: Oauth2Provider = Oauth2Provider.KAKAO
+        @PathVariable provider: OAuth2Provider = OAuth2Provider.KAKAO
     ) {
         // 실제 리디렉션은 Spring Security가 수행하므로 여기는 비어 있음
     }

--- a/eatngo-store-owner-api/src/main/kotlin/com/eatngo/config/WebConfig.kt
+++ b/eatngo-store-owner-api/src/main/kotlin/com/eatngo/config/WebConfig.kt
@@ -1,16 +1,16 @@
-package com.eatngo.auth.config
+package com.eatngo.config
 
-import com.eatngo.auth.resolver.UserAccountIdArgumentResolver
+import com.eatngo.auth.resolver.StoreOwnerIdArgumentResolver
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class WebConfig(
-    private val userAccountIdArgumentResolver: UserAccountIdArgumentResolver
+    private val storeOwnerIdArgumentResolver: StoreOwnerIdArgumentResolver
 ) : WebMvcConfigurer {
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
-        resolvers.add(userAccountIdArgumentResolver)
+        resolvers.add(storeOwnerIdArgumentResolver)
     }
 }

--- a/eatngo-store-owner-api/src/main/kotlin/com/eatngo/store_owner/StoreOwnerController.kt
+++ b/eatngo-store-owner-api/src/main/kotlin/com/eatngo/store_owner/StoreOwnerController.kt
@@ -2,7 +2,6 @@ package com.eatngo.store_owner
 
 import com.eatngo.auth.annotaion.StoreOwnerId
 import com.eatngo.common.response.ApiResponse
-import com.eatngo.oauth2.OAuth2Service
 import com.eatngo.store_owner.dto.StoreOwnerDto
 import com.eatngo.store_owner.dto.StoreOwnerUpdateDto
 import com.eatngo.store_owner.service.StoreOwnerService
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/v1/store-owners")
 class StoreOwnerController(
     private val storeOwnerService: StoreOwnerService,
-    private val oAuth2Service: Set<OAuth2Service>,
 ) {
     @Operation(summary = "고객 정보 조회 API", description = "고객 정보를 조회하는 API")
     @GetMapping("/me")
@@ -34,13 +32,7 @@ class StoreOwnerController(
     fun deleteCustomer(
         @StoreOwnerId storeOwnerId: Long,
     ): ResponseEntity<Unit> {
-        val storeOwner = storeOwnerService.getStoreOwnerById(storeOwnerId)
         storeOwnerService.deleteStoreOwner(storeOwnerId)
-        storeOwner.account.oAuth2.forEach { oauth2 ->
-            oAuth2Service.find {
-                it.supports(oauth2.provider)
-            }?.unlink(oauth2.accessToken)
-        }
         return ResponseEntity.noContent().build()
     }
 

--- a/eatngo-store-owner-api/src/main/kotlin/com/eatngo/store_owner/StoreOwnerController.kt
+++ b/eatngo-store-owner-api/src/main/kotlin/com/eatngo/store_owner/StoreOwnerController.kt
@@ -2,6 +2,7 @@ package com.eatngo.store_owner
 
 import com.eatngo.auth.annotaion.StoreOwnerId
 import com.eatngo.common.response.ApiResponse
+import com.eatngo.oauth2.OAuth2Service
 import com.eatngo.store_owner.dto.StoreOwnerDto
 import com.eatngo.store_owner.dto.StoreOwnerUpdateDto
 import com.eatngo.store_owner.service.StoreOwnerService
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/v1/store-owners")
 class StoreOwnerController(
     private val storeOwnerService: StoreOwnerService,
+    private val oAuth2Service: Set<OAuth2Service>,
 ) {
     @Operation(summary = "고객 정보 조회 API", description = "고객 정보를 조회하는 API")
     @GetMapping("/me")
@@ -32,7 +34,13 @@ class StoreOwnerController(
     fun deleteCustomer(
         @StoreOwnerId storeOwnerId: Long,
     ): ResponseEntity<Unit> {
+        val storeOwner = storeOwnerService.getStoreOwnerById(storeOwnerId)
         storeOwnerService.deleteStoreOwner(storeOwnerId)
+        storeOwner.account.oAuth2.forEach { oauth2 ->
+            oAuth2Service.find {
+                it.supports(oauth2.provider)
+            }?.unlink(oauth2.accessToken)
+        }
         return ResponseEntity.noContent().build()
     }
 

--- a/eatngo-store-owner-api/src/test/kotlin/com/eatngo/store_owner/StoreOwnerControllerTest.kt
+++ b/eatngo-store-owner-api/src/test/kotlin/com/eatngo/store_owner/StoreOwnerControllerTest.kt
@@ -6,7 +6,7 @@ import com.eatngo.configuration.TestConfiguration
 import com.eatngo.store_owner.dto.StoreOwnerDto
 import com.eatngo.store_owner.dto.StoreOwnerUpdateDto
 import com.eatngo.store_owner.service.StoreOwnerService
-import com.eatngo.user_account.oauth2.constants.Oauth2Provider
+import com.eatngo.user_account.oauth2.constants.OAuth2Provider
 import com.eatngo.user_account.oauth2.dto.KakaoOAuth2
 import com.eatngo.user_account.service.UserAccountService
 import com.eatngo.user_account.vo.Nickname
@@ -88,7 +88,7 @@ class StoreOwnerControllerTest(
                         "profile" to mapOf("nickname" to "홍길동")
                     )
                 ),
-                Oauth2Provider.KAKAO,
+                OAuth2Provider.KAKAO,
                 "token",
                 LocalDateTime.now().plusHours(1),
                 "profile,email"


### PR DESCRIPTION
## 🚀 PR 목적 (Goal)
<!-- 이 PR이 해결하려는 문제/목표를 한 문장으로 명확하게 작성해주세요. -->
- 고객, 점주의 탈퇴 시점에 계정을 삭제하는 것이 아닌, 모든 role이 제거 될 때 Account를 탈퇴하도록 한다.
- Account를 탈퇴 한 뒤 Oauth2인증을 모두 끊어준다.

---

## ✨ 주요 변경 사항 (Changes)
<!--
- 코드/구조/의존성 등 핵심 변경점만 요약
- ex) 주문 생성 API 추가, User 도메인 리팩토링, 결제 모듈 외부 API 연동 등
-->
- open feign 의존성 추가
- 고객, 점주 탈퇴 후 이벤트 발행 -> 계정에서 관련 role 제거 또는 모든 role이 없으면 계정 탈퇴
- 게정 탈퇴 후 이벤트 발행 -> 모든 oauth2 인증 끊기
- 분명 넣어줬던것 같은데 customerId, storeOwnerId를 넣어주는 Resolver를 넣어주던 설정이 안되고 있더라고요..? 🤔 다시 추가했습니다.
---

## 📝 상세 설명 (Description)
<!--
- 구현 방식, 고민한 점, 선택한 대안
- 기존과 달라진 동작, 예외 처리 등
- 리뷰어가 이해를 위해 미리 알면 좋은 내용
-->
- 점주 탈퇴 전에 활성화 된 가게가 있으면 탈퇴를 막는 검증 또는 탈퇴 시 가게 비활성화 등의 처리가 필요 할 겉 같아요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - Kakao OAuth2 연동 및 언링크 기능이 추가되었습니다.
    - 고객 및 점주 삭제 시 이벤트 기반으로 사용자 계정 및 연동 정보가 처리됩니다.
    - Spring Cloud OpenFeign 기반의 REST 클라이언트 기능이 도입되었습니다.

- **버그 수정**
    - OAuth2Provider 관련 클래스 및 프로퍼티 명칭의 일관성이 개선되었습니다.

- **리팩터**
    - 사용자 역할 컬렉션이 리스트에서 뮤터블 셋으로 변경되어 중복 방지 및 관리가 용이해졌습니다.

- **설정**
    - Kakao OAuth2 연동을 위한 API URL 등 설정이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->