### PR TITLE
[FEAT] totalStockCount redis에 반영 및 매장에 추가 연동 필요한 데이터 연동

### DIFF
--- a/eatngo-common/circuit-breaker/build.gradle.kts
+++ b/eatngo-common/circuit-breaker/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    kotlin("jvm")
+    kotlin("plugin.spring")
+}
+
+// Jar 태스크 활성화
+tasks.withType<Jar> {
+    enabled = true
+}
+
+dependencies {
+    implementation(platform("org.springframework.boot:spring-boot-dependencies:3.4.4"))
+    implementation("org.springframework:spring-context")
+    implementation("org.springframework:spring-aop")
+    implementation("org.aspectj:aspectjweaver")
+    implementation("io.micrometer:micrometer-core")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
+} 

--- a/eatngo-common/circuit-breaker/build.gradle.kts
+++ b/eatngo-common/circuit-breaker/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation("org.springframework:spring-aop")
     implementation("org.aspectj:aspectjweaver")
     implementation("io.micrometer:micrometer-core")
+    implementation("io.micrometer:micrometer-registry-prometheus")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")

--- a/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/annotation/RedisCircuitBreaker.kt
+++ b/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/annotation/RedisCircuitBreaker.kt
@@ -1,0 +1,18 @@
+package com.eatngo.common.circuitbreaker.annotation
+
+/**
+ * Redis Circuit Breaker 어노테이션
+ * 
+ * @param name Circuit Breaker 이름 (메트릭 태그로 사용)
+ * @param fallbackMethod fallback 메서드명 (같은 클래스 내에 있어야 함)
+ * @param failureThreshold 실패 임계값 (기본 5회)
+ * @param timeoutMinutes OPEN 상태 유지 시간 (기본 2분)
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RedisCircuitBreaker(
+    val name: String,
+    val fallbackMethod: String = "",
+    val failureThreshold: Int = 5,
+    val timeoutMinutes: Long = 2L
+) 

--- a/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/aspect/RedisCircuitBreakerAspect.kt
+++ b/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/aspect/RedisCircuitBreakerAspect.kt
@@ -1,0 +1,140 @@
+package com.eatngo.common.circuitbreaker.aspect
+
+import com.eatngo.common.circuitbreaker.annotation.RedisCircuitBreaker
+import com.eatngo.common.circuitbreaker.metrics.CircuitBreakerMetrics
+import com.eatngo.common.circuitbreaker.service.CircuitBreakerManager
+import mu.KotlinLogging
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.springframework.stereotype.Component
+import java.lang.reflect.Method
+import java.time.Duration
+import java.time.Instant
+
+@Aspect
+@Component
+class RedisCircuitBreakerAspect(
+    private val circuitBreakerManager: CircuitBreakerManager,
+    private val circuitBreakerMetrics: CircuitBreakerMetrics
+) {
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+    
+    @Around("@annotation(redisCircuitBreaker)")
+    fun aroundRedisCircuitBreaker(joinPoint: ProceedingJoinPoint, redisCircuitBreaker: RedisCircuitBreaker): Any? {
+        val circuitBreaker = circuitBreakerManager.getOrCreate(
+            redisCircuitBreaker.name,
+            redisCircuitBreaker.failureThreshold,
+            redisCircuitBreaker.timeoutMinutes
+        )
+        
+        val startTime = Instant.now()
+        val previousState = circuitBreaker.state.get()
+        
+        return try {
+            if (circuitBreakerManager.canExecute(circuitBreaker)) {
+                val result = joinPoint.proceed()
+                val executionTime = Duration.between(startTime, Instant.now())
+                
+                // 성공 처리
+                circuitBreakerManager.onSuccess(circuitBreaker)
+                circuitBreakerMetrics.recordSuccess(redisCircuitBreaker.name, executionTime)
+                
+                // 상태 변경 체크
+                val currentState = circuitBreaker.state.get()
+                if (previousState != currentState) {
+                    logger.info { "Circuit Breaker [${redisCircuitBreaker.name}] state changed: $previousState -> $currentState" }
+                    circuitBreakerMetrics.recordStateChange(redisCircuitBreaker.name, previousState, currentState)
+                }
+                
+                result
+            } else {
+                // Circuit Breaker가 OPEN 상태인 경우 fallback 실행
+                logger.warn { "Circuit Breaker [${redisCircuitBreaker.name}] is OPEN, executing fallback" }
+                executeFallback(joinPoint, redisCircuitBreaker, "Circuit breaker is OPEN")
+            }
+        } catch (ex: Exception) {
+            val executionTime = Duration.between(startTime, Instant.now())
+            
+            // 실패 처리
+            circuitBreakerManager.onFailure(circuitBreaker)
+            circuitBreakerMetrics.recordFailure(redisCircuitBreaker.name, executionTime, ex)
+            
+            // 상태 변경 체크
+            val currentState = circuitBreaker.state.get()
+            if (previousState != currentState) {
+                logger.warn { "Circuit Breaker [${redisCircuitBreaker.name}] state changed due to failure: $previousState -> $currentState" }
+                circuitBreakerMetrics.recordStateChange(redisCircuitBreaker.name, previousState, currentState)
+            }
+            
+            // 실패 로그
+            logger.error { "Circuit Breaker [${redisCircuitBreaker.name}] execution failed: ${ex.message}" }
+            
+            // fallback 실행
+            executeFallback(joinPoint, redisCircuitBreaker, "Exception: ${ex.message}")
+        }
+    }
+    
+    private fun executeFallback(
+        joinPoint: ProceedingJoinPoint,
+        redisCircuitBreaker: RedisCircuitBreaker,
+        reason: String
+    ): Any? {
+        val fallbackMethodName = redisCircuitBreaker.fallbackMethod
+        
+        return if (fallbackMethodName.isNotEmpty()) {
+            try {
+                logger.info { "Circuit Breaker [${redisCircuitBreaker.name}] executing fallback: $fallbackMethodName" }
+                circuitBreakerMetrics.recordFallback(redisCircuitBreaker.name, reason)
+                invokeFallbackMethod(joinPoint, fallbackMethodName)
+            } catch (fallbackEx: Exception) {
+                logger.error(fallbackEx) { "Circuit Breaker [${redisCircuitBreaker.name}] fallback failed: $fallbackMethodName" }
+                throw fallbackEx
+            }
+        } else {
+            logger.warn { "Circuit Breaker [${redisCircuitBreaker.name}] no fallback method specified" }
+            null
+        }
+    }
+    
+    private fun invokeFallbackMethod(joinPoint: ProceedingJoinPoint, fallbackMethodName: String): Any? {
+        val target = joinPoint.target
+        val targetClass = target.javaClass
+        val originalArgs = joinPoint.args
+        
+        // fallback 메서드 찾기 (파라미터 타입 + Exception 타입)
+        val fallbackMethod = findFallbackMethod(targetClass, fallbackMethodName, originalArgs)
+            ?: throw NoSuchMethodException("Fallback method '$fallbackMethodName' not found in ${targetClass.simpleName}")
+        
+        return if (fallbackMethod.parameterCount == originalArgs.size + 1) {
+            // Exception 파라미터가 있는 경우
+            val argsWithException = originalArgs + RuntimeException("Circuit breaker triggered")
+            fallbackMethod.invoke(target, *argsWithException)
+        } else {
+            // Exception 파라미터가 없는 경우
+            fallbackMethod.invoke(target, *originalArgs)
+        }
+    }
+    
+    private fun findFallbackMethod(targetClass: Class<*>, methodName: String, args: Array<Any?>): Method? {
+        val parameterTypes = args.map { it?.javaClass ?: Any::class.java }.toTypedArray()
+        
+        return try {
+            // 정확한 파라미터 타입으로 찾기
+            targetClass.getDeclaredMethod(methodName, *parameterTypes)
+        } catch (ex: NoSuchMethodException) {
+            try {
+                // Exception 파라미터 추가해서 찾기
+                targetClass.getDeclaredMethod(methodName, *parameterTypes, Exception::class.java)
+            } catch (ex2: NoSuchMethodException) {
+                // 메서드명만으로 찾기 (파라미터 개수가 맞는 첫 번째 메서드)
+                targetClass.declaredMethods.find { method ->
+                    method.name == methodName && 
+                    (method.parameterCount == args.size || method.parameterCount == args.size + 1)
+                }
+            }
+        }
+    }
+} 

--- a/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/config/CircuitBreakerConfig.kt
+++ b/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/config/CircuitBreakerConfig.kt
@@ -1,0 +1,30 @@
+package com.eatngo.common.circuitbreaker.config
+
+import com.eatngo.common.circuitbreaker.metrics.CircuitBreakerMetrics
+import mu.KotlinLogging
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.EnableAspectJAutoProxy
+import org.springframework.context.event.ContextRefreshedEvent
+import org.springframework.context.event.EventListener
+
+@Configuration
+@EnableAspectJAutoProxy
+@ComponentScan(basePackages = ["com.eatngo.common.circuitbreaker"])
+class CircuitBreakerConfig(
+    private val circuitBreakerMetrics: CircuitBreakerMetrics
+) {
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+    
+    @EventListener(ContextRefreshedEvent::class)
+    fun initializeMetrics() {
+        try {
+            circuitBreakerMetrics.registerStateGauges()
+            logger.info { "Circuit Breaker metrics initialized successfully" }
+        } catch (ex: Exception) {
+            logger.error(ex) { "Circuit Breaker metrics initialization failed: ${ex.message}" }
+        }
+    }
+} 

--- a/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/config/CircuitBreakerConfig.kt
+++ b/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/config/CircuitBreakerConfig.kt
@@ -1,6 +1,5 @@
 package com.eatngo.common.circuitbreaker.config
 
-import com.eatngo.common.circuitbreaker.metrics.CircuitBreakerMetrics
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import mu.KotlinLogging
@@ -8,15 +7,11 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.EnableAspectJAutoProxy
-import org.springframework.context.event.ContextRefreshedEvent
-import org.springframework.context.event.EventListener
 
 @Configuration
 @EnableAspectJAutoProxy
 @ComponentScan(basePackages = ["com.eatngo.common.circuitbreaker"])
-class CircuitBreakerConfig(
-    private val circuitBreakerMetrics: CircuitBreakerMetrics
-) {
+class CircuitBreakerConfig {
     companion object {
         private val logger = KotlinLogging.logger {}
     }
@@ -24,15 +19,5 @@ class CircuitBreakerConfig(
     @Bean
     fun meterRegistry(): MeterRegistry {
         return SimpleMeterRegistry()
-    }
-    
-    @EventListener(ContextRefreshedEvent::class)
-    fun initializeMetrics() {
-        try {
-            circuitBreakerMetrics.registerStateGauges()
-            logger.info { "Circuit Breaker metrics initialized successfully" }
-        } catch (ex: Exception) {
-            logger.error(ex) { "Circuit Breaker metrics initialization failed: ${ex.message}" }
-        }
     }
 } 

--- a/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/config/CircuitBreakerConfig.kt
+++ b/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/config/CircuitBreakerConfig.kt
@@ -1,7 +1,10 @@
 package com.eatngo.common.circuitbreaker.config
 
 import com.eatngo.common.circuitbreaker.metrics.CircuitBreakerMetrics
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import mu.KotlinLogging
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.EnableAspectJAutoProxy
@@ -16,6 +19,11 @@ class CircuitBreakerConfig(
 ) {
     companion object {
         private val logger = KotlinLogging.logger {}
+    }
+
+    @Bean
+    fun meterRegistry(): MeterRegistry {
+        return SimpleMeterRegistry()
     }
     
     @EventListener(ContextRefreshedEvent::class)

--- a/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/metrics/CircuitBreakerMetrics.kt
+++ b/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/metrics/CircuitBreakerMetrics.kt
@@ -1,0 +1,130 @@
+package com.eatngo.common.circuitbreaker.metrics
+
+import com.eatngo.common.circuitbreaker.service.CircuitBreakerManager
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class CircuitBreakerMetrics(
+    private val meterRegistry: MeterRegistry?,
+    private val circuitBreakerManager: CircuitBreakerManager
+) {
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+    
+    private val successCounters = mutableMapOf<String, Counter>()
+    private val failureCounters = mutableMapOf<String, Counter>()
+    private val fallbackCounters = mutableMapOf<String, Counter>()
+    private val timers = mutableMapOf<String, Timer>()
+    
+    fun recordSuccess(circuitBreakerName: String, executionTime: Duration) {
+        meterRegistry?.let {
+            getSuccessCounter(circuitBreakerName).increment()
+            getTimer(circuitBreakerName).record(executionTime)
+        }
+        
+        logger.debug { "Circuit Breaker [$circuitBreakerName] Success - ${executionTime.toMillis()}ms" }
+    }
+    
+    fun recordFailure(circuitBreakerName: String, executionTime: Duration, exception: Throwable) {
+        meterRegistry?.let {
+            getFailureCounter(circuitBreakerName).increment()
+            getTimer(circuitBreakerName).record(executionTime)
+        }
+        
+        logger.warn { "Circuit Breaker [$circuitBreakerName] Failure - ${executionTime.toMillis()}ms, error: ${exception.message}" }
+    }
+    
+    fun recordFallback(circuitBreakerName: String, reason: String) {
+        meterRegistry?.let {
+            getFallbackCounter(circuitBreakerName).increment()
+        }
+        
+        logger.info { "Circuit Breaker [$circuitBreakerName] Fallback executed - reason: $reason" }
+    }
+    
+    fun recordStateChange(circuitBreakerName: String, fromState: CircuitBreakerManager.State, toState: CircuitBreakerManager.State) {
+        meterRegistry?.let { registry ->
+            Counter.builder("circuit_breaker_state_transitions")
+                .tag("name", circuitBreakerName)
+                .tag("from_state", fromState.name)
+                .tag("to_state", toState.name)
+                .register(registry)
+                .increment()
+        }
+        
+        logger.warn { "Circuit Breaker [$circuitBreakerName] State Changed: $fromState -> $toState" }
+    }
+    
+    private fun getSuccessCounter(name: String): Counter {
+        return successCounters.computeIfAbsent(name) {
+            Counter.builder("circuit_breaker_calls")
+                .tag("name", name)
+                .tag("result", "success")
+                .description("Circuit breaker successful calls")
+                .register(meterRegistry!!)
+        }
+    }
+    
+    private fun getFailureCounter(name: String): Counter {
+        return failureCounters.computeIfAbsent(name) {
+            Counter.builder("circuit_breaker_calls")
+                .tag("name", name)
+                .tag("result", "failure")
+                .description("Circuit breaker failed calls")
+                .register(meterRegistry!!)
+        }
+    }
+    
+    private fun getFallbackCounter(name: String): Counter {
+        return fallbackCounters.computeIfAbsent(name) {
+            Counter.builder("circuit_breaker_fallbacks")
+                .tag("name", name)
+                .description("Circuit breaker fallback executions")
+                .register(meterRegistry!!)
+        }
+    }
+    
+    private fun getTimer(name: String): Timer {
+        return timers.computeIfAbsent(name) {
+            Timer.builder("circuit_breaker_calls_duration")
+                .tag("name", name)
+                .description("Circuit breaker call duration")
+                .register(meterRegistry!!)
+        }
+    }
+    
+    /**
+     * Circuit Breaker 상태를 Gauge로 등록
+     */
+    fun registerStateGauges() {
+        meterRegistry?.let { registry ->
+            circuitBreakerManager.getAllStates().forEach { (name, _) ->
+                registry.gauge("circuit_breaker_state",
+                    listOf(io.micrometer.core.instrument.Tag.of("name", name)),
+                    circuitBreakerManager
+                ) { manager ->
+                    when (manager.getState(name)) {
+                        CircuitBreakerManager.State.CLOSED -> 0.0
+                        CircuitBreakerManager.State.OPEN -> 1.0
+                        CircuitBreakerManager.State.HALF_OPEN -> 2.0
+                        null -> -1.0
+                    }
+                }
+                
+                // Circuit Breaker 실패 카운트 Gauge
+                registry.gauge("circuit_breaker_failure_count",
+                    listOf(io.micrometer.core.instrument.Tag.of("name", name)),
+                    circuitBreakerManager
+                ) { manager ->
+                    manager.getFailureCount(name).toDouble()
+                }
+            }
+        }
+    }
+} 

--- a/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/metrics/CircuitBreakerMetrics.kt
+++ b/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/metrics/CircuitBreakerMetrics.kt
@@ -8,6 +8,7 @@ import mu.KotlinLogging
 import org.springframework.beans.factory.InitializingBean
 import org.springframework.stereotype.Component
 import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
 
 @Component
 class CircuitBreakerMetrics(
@@ -18,10 +19,10 @@ class CircuitBreakerMetrics(
         private val logger = KotlinLogging.logger {}
     }
     
-    private val successCounters = mutableMapOf<String, Counter>()
-    private val failureCounters = mutableMapOf<String, Counter>()
-    private val fallbackCounters = mutableMapOf<String, Counter>()
-    private val timers = mutableMapOf<String, Timer>()
+    private val successCounters = ConcurrentHashMap<String, Counter>()
+    private val failureCounters = ConcurrentHashMap<String, Counter>()
+    private val fallbackCounters = ConcurrentHashMap<String, Counter>()
+    private val timers = ConcurrentHashMap<String, Timer>()
     
     override fun afterPropertiesSet() {
         try {

--- a/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/service/CircuitBreakerManager.kt
+++ b/eatngo-common/circuit-breaker/src/main/kotlin/com/eatngo/common/circuitbreaker/service/CircuitBreakerManager.kt
@@ -1,0 +1,79 @@
+package com.eatngo.common.circuitbreaker.service
+
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+@Component
+class CircuitBreakerManager {
+    
+    private val circuitBreakers = ConcurrentHashMap<String, CircuitBreakerState>()
+    
+    enum class State {
+        CLOSED,    // 정상 상태
+        OPEN,      // 장애 상태
+        HALF_OPEN  // 복구 시도 상태
+    }
+    
+    data class CircuitBreakerState(
+        val name: String,
+        val failureThreshold: Int,
+        val timeoutMinutes: Long,
+        val failureCount: AtomicInteger = AtomicInteger(0),
+        val lastFailureTime: AtomicReference<LocalDateTime> = AtomicReference(),
+        val state: AtomicReference<State> = AtomicReference(State.CLOSED)
+    )
+    
+    fun getOrCreate(name: String, failureThreshold: Int, timeoutMinutes: Long): CircuitBreakerState {
+        return circuitBreakers.computeIfAbsent(name) {
+            CircuitBreakerState(name, failureThreshold, timeoutMinutes)
+        }
+    }
+    
+    fun canExecute(circuitBreaker: CircuitBreakerState): Boolean {
+        return when (circuitBreaker.state.get()) {
+            State.CLOSED -> true
+            State.HALF_OPEN -> true
+            State.OPEN -> shouldAttemptReset(circuitBreaker)
+        }
+    }
+    
+    fun onSuccess(circuitBreaker: CircuitBreakerState) {
+        circuitBreaker.failureCount.set(0)
+        circuitBreaker.state.set(State.CLOSED)
+    }
+    
+    fun onFailure(circuitBreaker: CircuitBreakerState) {
+        circuitBreaker.lastFailureTime.set(LocalDateTime.now())
+        val failures = circuitBreaker.failureCount.incrementAndGet()
+        
+        if (failures >= circuitBreaker.failureThreshold) {
+            circuitBreaker.state.set(State.OPEN)
+        }
+    }
+    
+    private fun shouldAttemptReset(circuitBreaker: CircuitBreakerState): Boolean {
+        val lastFailure = circuitBreaker.lastFailureTime.get() ?: return false
+        val shouldReset = lastFailure.plusMinutes(circuitBreaker.timeoutMinutes).isBefore(LocalDateTime.now())
+        
+        if (shouldReset) {
+            circuitBreaker.state.set(State.HALF_OPEN)
+        }
+        
+        return shouldReset
+    }
+    
+    fun getAllStates(): Map<String, State> {
+        return circuitBreakers.mapValues { it.value.state.get() }
+    }
+    
+    fun getState(name: String): State? {
+        return circuitBreakers[name]?.state?.get()
+    }
+    
+    fun getFailureCount(name: String): Int {
+        return circuitBreakers[name]?.failureCount?.get() ?: 0
+    }
+} 

--- a/eatngo-core/build.gradle.kts
+++ b/eatngo-core/build.gradle.kts
@@ -20,6 +20,12 @@ dependencies {
     // 테스트 의존성
     testImplementation("io.kotest:kotest-runner-junit5:5.8.1")
     testImplementation("io.kotest:kotest-assertions-core:5.8.1")
+
+    // Circuit Breaker 모듈
+    implementation(project(":eatngo-common:circuit-breaker"))
+    
+    // AOP 지원 (Circuit Breaker용)
+    implementation("org.springframework.boot:spring-boot-starter-aop")
 }
 
 tasks.bootJar{

--- a/eatngo-core/src/main/kotlin/com/eatngo/common/constant/StoreEnum.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/common/constant/StoreEnum.kt
@@ -57,9 +57,7 @@ object StoreEnum {
         val category: String,
     ) {
         BREAD("빵"),
-        BAKERY("베이커리"),
         CAFE("카페"),
-        DESSERT("디저트"),
         KOREAN("한식"),
         FRUIT("과일"),
         PIZZA("피자"),

--- a/eatngo-core/src/main/kotlin/com/eatngo/common/error/BusinessErrorCode.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/common/error/BusinessErrorCode.kt
@@ -99,6 +99,7 @@ enum class BusinessErrorCode(
     // 재고 관련 오류
     STOCK_NOT_FOUND("ST001", "상품의 재고를 찾을 수 없습니다.", 400),
     STOCK_EMPTY("ST002", "상품의 재고가 없습니다.", 409),
-    INVENTORY_NOT_FOUND("I001", "상품 재고를 찾을 수 없습니다.", 400)
+    INVENTORY_NOT_FOUND("I001", "상품 재고를 찾을 수 없습니다.", 400),
+    STORE_TOTAL_STOCK_QUERY_FAILED("ST003", "매장 총 재고 조회에 실패했습니다.", 500),
 
 }

--- a/eatngo-core/src/main/kotlin/com/eatngo/common/exception/BusinessException.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/common/exception/BusinessException.kt
@@ -8,4 +8,5 @@ abstract class BusinessException(
     override val message: String = errorCode.message,
     open val data: Map<String, Any>? = null,
     open val logLevel: Level = Level.WARN,
-) : RuntimeException(message)
+    override val cause: Throwable? = null
+) : RuntimeException(message, cause)

--- a/eatngo-core/src/main/kotlin/com/eatngo/common/exception/store/StoreException.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/common/exception/store/StoreException.kt
@@ -6,14 +6,15 @@ import com.eatngo.common.exception.BusinessException
 import org.slf4j.event.Level
 
 /**
- * 매장(점주) 관련 예외
+ * 매장 관련 예외
  */
 open class StoreException(
     override val errorCode: BusinessErrorCode,
     override val message: String = errorCode.message,
     override val data: Map<String, Any>? = null,
     override val logLevel: Level = Level.WARN,
-) : BusinessException(errorCode, message, data, logLevel) {
+    override val cause: Throwable? = null
+) : BusinessException(errorCode, message, data, logLevel, cause) {
 
     class StoreNotFound(storeId: Long) : StoreException(
         errorCode = BusinessErrorCode.STORE_NOT_FOUND,
@@ -70,5 +71,16 @@ open class StoreException(
             "storeIds" to storeIds
         ),
         logLevel = Level.ERROR
+    )
+
+    class StoreTotalStockException(
+        storeId: Long,
+        cause: Throwable? = null
+    ) : StoreException(
+        errorCode = BusinessErrorCode.STORE_TOTAL_STOCK_QUERY_FAILED,
+        message = "FallBack 로직으로 매장 DB 총 재고 조회 실패: storeId=$storeId",
+        data = mapOf("storeId" to storeId),
+        cause = cause,
+        logLevel = Level.WARN
     )
 }

--- a/eatngo-core/src/main/kotlin/com/eatngo/product/infra/ProductPersistence.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/product/infra/ProductPersistence.kt
@@ -8,5 +8,5 @@ interface ProductPersistence {
     fun findAllActivatedProductByStoreId(storeId: Long): List<Product>
     fun findAllActivatedProductsByStoreIds(storeIds: List<Long>): List<Product>
     fun findActivatedProductByIdAndStoreId(productId: Long, storeId: Long): Product?
-    fun countActiveProductsByStoreId(storeId: Long): Int
+    fun countActiveProductsByStoreId(storeId: Long): Long
 }

--- a/eatngo-core/src/main/kotlin/com/eatngo/product/infra/ProductPersistence.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/product/infra/ProductPersistence.kt
@@ -8,4 +8,5 @@ interface ProductPersistence {
     fun findAllActivatedProductByStoreId(storeId: Long): List<Product>
     fun findAllActivatedProductsByStoreIds(storeIds: List<Long>): List<Product>
     fun findActivatedProductByIdAndStoreId(productId: Long, storeId: Long): Product?
+    fun countActiveProductsByStoreId(storeId: Long): Int
 }

--- a/eatngo-core/src/main/kotlin/com/eatngo/store/dto/StoreDto.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/store/dto/StoreDto.kt
@@ -1,6 +1,7 @@
 package com.eatngo.store.dto
 
 import com.eatngo.common.constant.StoreEnum
+import com.eatngo.review.dto.StoreReviewStatsDto
 import com.eatngo.store.domain.Store
 import java.time.DayOfWeek
 import java.time.LocalDateTime
@@ -31,7 +32,17 @@ data class StoreDto(
     var deletedAt: LocalDateTime?,
 ) {
     companion object {
+        /**
+         * 리뷰 데이터 없이 Store 도메인을 StoreDto로 변환
+         */
         fun from(store: Store): StoreDto {
+            return from(store, null)
+        }
+        
+        /**
+         * Store 도메인과 리뷰 집계 데이터를 StoreDto로 변환
+         */
+        fun from(store: Store, reviewStats: StoreReviewStatsDto?): StoreDto {
             val today = java.time.LocalDate.now().dayOfWeek
             val todayHour = store.businessHours?.find { it.dayOfWeek == today }
             return StoreDto(
@@ -67,9 +78,8 @@ data class StoreDto(
                 todayPickupStartTime = todayHour?.openTime,
                 todayPickupEndTime = todayHour?.closeTime,
                 reviewInfo = ReviewInfoDto(
-                    //TODO: 리뷰는 dto에만 포함, 추후 기능 개발되면 서비스에서 값 가져와야 함
-                    ratingAverage = 0.0,
-                    ratingCount = 0
+                    ratingAverage = reviewStats?.averageRating?.toDouble() ?: 0.0,
+                    ratingCount = reviewStats?.totalReviewCount ?: 0
                 ),
                 createdAt = store.createdAt,
                 updatedAt = store.updatedAt,

--- a/eatngo-core/src/main/kotlin/com/eatngo/store/infra/StoreTotalStockRedisRepository.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/store/infra/StoreTotalStockRedisRepository.kt
@@ -1,0 +1,23 @@
+package com.eatngo.store.infra
+
+import java.time.LocalDate
+
+interface StoreTotalStockRedisRepository {
+    /**
+     * 매장의 특정 날짜 총 재고 수량을 설정
+     * Key: {storeId}:{yyyyMMdd}:totalCount
+     * TTL: 24시간
+     */
+    fun setStoreTotalStock(storeId: Long, date: LocalDate, totalStock: Int)
+
+    /**
+     * 매장의 특정 날짜 총 재고 수량을 조회
+     * @return 재고 수량 (null: 오늘 판매 안함 또는 데이터 없음)
+     */
+    fun getStoreTotalStock(storeId: Long, date: LocalDate): Int?
+
+    /**
+     * 매장의 재고 데이터 삭제
+     */
+    fun deleteStoreTotalStock(storeId: Long, date: LocalDate)
+}

--- a/eatngo-core/src/main/kotlin/com/eatngo/store/service/StoreTotalStockService.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/store/service/StoreTotalStockService.kt
@@ -1,0 +1,149 @@
+package com.eatngo.store.service
+
+import com.eatngo.inventory.infra.InventoryPersistence
+import com.eatngo.product.infra.ProductPersistence
+import com.eatngo.store.infra.StoreTotalStockRedisRepository
+import com.eatngo.common.circuitbreaker.annotation.RedisCircuitBreaker
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.util.concurrent.ConcurrentHashMap
+
+@Service
+class StoreTotalStockService(
+    private val storeTotalStockRedisRepository: StoreTotalStockRedisRepository,
+    private val inventoryPersistence: InventoryPersistence,
+    private val productPersistence: ProductPersistence
+) {
+    
+    // 로컬 메모리 캐시 (앱 재시작까지 유지)
+    private val localCache = ConcurrentHashMap<String, CachedStockInfo>()
+    
+    data class CachedStockInfo(
+        val stock: Int,
+        val cachedAt: Long = System.currentTimeMillis(),
+        val ttlMs: Long = 300_000L // 5분
+    ) {
+        fun isExpired(): Boolean = System.currentTimeMillis() - cachedAt > ttlMs
+    }
+
+    /**
+     * 매장의 총 재고 수량을 조회 (프론트 응답용)
+     * @return 재고 수량 (-1: 오늘 판매 안함, 0 이상: 실제 재고)
+     */
+    @RedisCircuitBreaker(
+        name = "store-total-stock-get",
+        fallbackMethod = "getStoreTotalStockFallback",
+        failureThreshold = 3,
+        timeoutMinutes = 1L
+    )
+    fun getStoreTotalStockForResponse(storeId: Long, date: LocalDate = LocalDate.now()): Int {
+        val redisStock = storeTotalStockRedisRepository.getStoreTotalStock(storeId, date)
+        return redisStock ?: -1 // null이면 -1 반환 (오늘 판매 안함)
+    }
+
+    /**
+     * fallback 메서드
+     */
+    fun getStoreTotalStockFallback(storeId: Long, date: LocalDate, ex: Exception): Int {
+        val cacheKey = "${storeId}:${date}"
+        
+        // 로컬 메모리 캐시 확인
+        localCache[cacheKey]?.let { cached ->
+            if (!cached.isExpired()) {
+                return cached.stock
+            } else {
+                localCache.remove(cacheKey)
+            }
+        }
+
+        // 위에서 로컬 캐시로 해결 안 되면 DB 조회
+        return try {
+            if (shouldAllowDbQuery(storeId)) {
+                val dbStock = calculateTotalStockFromDBWithLimit(storeId)
+                localCache[cacheKey] = CachedStockInfo(dbStock)
+                
+                dbStock
+            } else {
+                // DB 조회도 제한된 경우 - 기본값 반환
+                getDefaultStock(storeId)
+            }
+        } catch (dbEx: Exception) {
+            getDefaultStock(storeId)
+        }
+    }
+    
+    // DB 조회 제한 로직 (매장별로 분당 최대 2회)
+    private val dbQueryTracker = ConcurrentHashMap<Long, MutableList<Long>>()
+    
+    private fun shouldAllowDbQuery(storeId: Long): Boolean {
+        val now = System.currentTimeMillis()
+        val queries = dbQueryTracker.computeIfAbsent(storeId) { mutableListOf() }
+        
+        queries.removeIf { it < now - 60_000L }
+        
+        if (queries.size >= 2) return false
+        
+        queries.add(now)
+        return true
+    }
+    
+    /**
+     * 제한된 DB 조회 - 필수 정보만 조회
+     */
+    private fun calculateTotalStockFromDBWithLimit(storeId: Long): Int {
+        val activeProductCount = productPersistence.countActiveProductsByStoreId(storeId)
+        
+        if (activeProductCount == 0) return 0
+
+        val products = productPersistence.findAllActivatedProductByStoreId(storeId)
+        val productIds = products.map { it.id }
+        val latestInventories = inventoryPersistence.findLatestByProductIds(productIds)
+        return latestInventories.sumOf { it.stock }
+    }
+    
+    /**
+     * 기본 재고값 반환 (Redis, DB 모두 실패 시)
+     */
+    private fun getDefaultStock(storeId: Long): Int {
+        val cacheKey = "${storeId}:${LocalDate.now()}"
+        localCache[cacheKey]?.let { cached ->
+            return cached.stock
+        }
+        
+        return -1 // 판매 안함으로 처리
+    }
+
+    /**
+     * 매장의 총 재고 수량을 Redis에 설정 (이벤트 처리용)
+     */
+    @RedisCircuitBreaker(
+        name = "store-total-stock-set",
+        fallbackMethod = "setStoreTotalStockFallback",
+        failureThreshold = 5,
+        timeoutMinutes = 2L
+    )
+    fun setStoreTotalStock(storeId: Long, newTotalStock: Int, date: LocalDate = LocalDate.now()) {
+        // 재고가 0 이상인 경우에만 Redis에 저장(-1은 애초에 재고 설정 안 한거라 저장할 필요가 없음)
+        if (newTotalStock >= 0) {
+            storeTotalStockRedisRepository.setStoreTotalStock(storeId, date, newTotalStock)
+            
+            val cacheKey = "${storeId}:${date}"
+            localCache[cacheKey] = CachedStockInfo(newTotalStock)
+        } else {
+            storeTotalStockRedisRepository.deleteStoreTotalStock(storeId, date)
+            localCache.remove("${storeId}:${date}")
+        }
+    }
+
+    /**
+     * setStoreTotalStock의 fallback 메서드 - 로컬 캐시만 업데이트
+     */
+    fun setStoreTotalStockFallback(storeId: Long, newTotalStock: Int, date: LocalDate, ex: Exception) {
+        val cacheKey = "${storeId}:${date}"
+        if (newTotalStock >= 0) {
+            localCache[cacheKey] = CachedStockInfo(newTotalStock)
+        } else {
+            localCache.remove(cacheKey)
+        }
+    }
+}

--- a/eatngo-core/src/main/kotlin/com/eatngo/store/usecase/StoreQueryUseCase.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/store/usecase/StoreQueryUseCase.kt
@@ -1,5 +1,6 @@
 package com.eatngo.store.usecase
 
+import com.eatngo.review.service.StoreReviewStatsService
 import com.eatngo.store.dto.StoreDto
 import com.eatngo.store.service.StoreService
 import org.springframework.stereotype.Service
@@ -7,17 +8,25 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class StoreQueryUseCase(
-    private val storeService: StoreService
+    private val storeService: StoreService,
+    private val storeReviewStatsService: StoreReviewStatsService
 ) {
     @Transactional(readOnly = true)
     fun getStoreById(storeId: Long): StoreDto {
         val store = storeService.getStoreById(storeId)
-        return StoreDto.from(store)
+        val reviewStats = storeReviewStatsService.getStoreReviewStats(storeId)
+        return StoreDto.from(store, reviewStats)
     }
 
     @Transactional(readOnly = true)
     fun getStoresByStoreOwnerId(storeOwnerId: Long): List<StoreDto> {
         val stores = storeService.getStoresByStoreOwnerId(storeOwnerId)
-        return stores.map { StoreDto.from(it) }
+        val storeIds = stores.map { it.id }
+        val reviewStatsMap = storeReviewStatsService.getStoreReviewStats(storeIds)
+        
+        return stores.map { store ->
+            val reviewStats = reviewStatsMap[store.id]
+            StoreDto.from(store, reviewStats)
+        }
     }
 }

--- a/eatngo-infra/src/main/kotlin/com/eatngo/product/persistence/JpaProductRepository.kt
+++ b/eatngo-infra/src/main/kotlin/com/eatngo/product/persistence/JpaProductRepository.kt
@@ -16,5 +16,5 @@ interface JpaProductRepository : JpaRepository<ProductEntity, Long> {
         deleteStatus: DeletedStatus
     ): Optional<ProductEntity>
     
-    fun countByStoreIdAndDeleteStatus(storeId: Long, deleteStatus: DeletedStatus): Int
+    fun countByStoreIdAndDeleteStatus(storeId: Long, deleteStatus: DeletedStatus): Long
 }

--- a/eatngo-infra/src/main/kotlin/com/eatngo/product/persistence/JpaProductRepository.kt
+++ b/eatngo-infra/src/main/kotlin/com/eatngo/product/persistence/JpaProductRepository.kt
@@ -15,4 +15,6 @@ interface JpaProductRepository : JpaRepository<ProductEntity, Long> {
         storeId: Long,
         deleteStatus: DeletedStatus
     ): Optional<ProductEntity>
+    
+    fun countByStoreIdAndDeleteStatus(storeId: Long, deleteStatus: DeletedStatus): Int
 }

--- a/eatngo-infra/src/main/kotlin/com/eatngo/product/persistence/ProductPersistenceImpl.kt
+++ b/eatngo-infra/src/main/kotlin/com/eatngo/product/persistence/ProductPersistenceImpl.kt
@@ -37,4 +37,8 @@ class ProductPersistenceImpl(
         return productRepository.findAllByStoreIdInAndDeleteStatus(storeIds, DeletedStatus.ACTIVE)
             .map(ProductMapper::toDomain)
     }
+
+    override fun countActiveProductsByStoreId(storeId: Long): Int {
+        return productRepository.countByStoreIdAndDeleteStatus(storeId, DeletedStatus.ACTIVE)
+    }
 }

--- a/eatngo-infra/src/main/kotlin/com/eatngo/product/persistence/ProductPersistenceImpl.kt
+++ b/eatngo-infra/src/main/kotlin/com/eatngo/product/persistence/ProductPersistenceImpl.kt
@@ -38,7 +38,7 @@ class ProductPersistenceImpl(
             .map(ProductMapper::toDomain)
     }
 
-    override fun countActiveProductsByStoreId(storeId: Long): Int {
+    override fun countActiveProductsByStoreId(storeId: Long): Long {
         return productRepository.countByStoreIdAndDeleteStatus(storeId, DeletedStatus.ACTIVE)
     }
 }

--- a/eatngo-infra/src/main/kotlin/com/eatngo/redis/repository/store/StoreTotalStockRedisRepositoryImpl.kt
+++ b/eatngo-infra/src/main/kotlin/com/eatngo/redis/repository/store/StoreTotalStockRedisRepositoryImpl.kt
@@ -1,0 +1,39 @@
+package com.eatngo.redis.repository.store
+
+import com.eatngo.store.infra.StoreTotalStockRedisRepository
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Repository
+import java.time.Duration
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@Repository
+class StoreTotalStockRedisRepositoryImpl(
+    private val redisTemplate: RedisTemplate<String, String>
+) : StoreTotalStockRedisRepository {
+
+    companion object {
+        private const val STORE_TOTAL_STOCK_KEY = "%d:%s:totalCount" // {storeId}:{yyyyMMdd}:totalCount
+        private const val TTL_HOURS = 24L
+        private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd")
+    }
+
+    override fun setStoreTotalStock(storeId: Long, date: LocalDate, totalStock: Int) {
+        val key = generateKey(storeId, date)
+        redisTemplate.opsForValue().set(key, totalStock.toString(), Duration.ofHours(TTL_HOURS))
+    }
+
+    override fun getStoreTotalStock(storeId: Long, date: LocalDate): Int? {
+        val key = generateKey(storeId, date)
+        return redisTemplate.opsForValue().get(key)?.toIntOrNull()
+    }
+
+    override fun deleteStoreTotalStock(storeId: Long, date: LocalDate) {
+        val key = generateKey(storeId, date)
+        redisTemplate.delete(key)
+    }
+
+    private fun generateKey(storeId: Long, date: LocalDate): String {
+        return STORE_TOTAL_STOCK_KEY.format(storeId, date.format(DATE_FORMATTER))
+    }
+}

--- a/eatngo-infra/src/main/kotlin/com/eatngo/redis/repository/store/StoreTotalStockRedisRepositoryImpl.kt
+++ b/eatngo-infra/src/main/kotlin/com/eatngo/redis/repository/store/StoreTotalStockRedisRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.eatngo.redis.repository.store
 
 import com.eatngo.store.infra.StoreTotalStockRedisRepository
-import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Repository
 import java.time.Duration
 import java.time.LocalDate
@@ -9,7 +9,7 @@ import java.time.format.DateTimeFormatter
 
 @Repository
 class StoreTotalStockRedisRepositoryImpl(
-    private val redisTemplate: RedisTemplate<String, String>
+    private val stringRedisTemplate: StringRedisTemplate
 ) : StoreTotalStockRedisRepository {
 
     companion object {
@@ -19,18 +19,19 @@ class StoreTotalStockRedisRepositoryImpl(
     }
 
     override fun setStoreTotalStock(storeId: Long, date: LocalDate, totalStock: Int) {
+        require(totalStock >= 0) { "총 재고는 음수가 될 수 없습니다. Redis에 저장 실패: (storeId: $storeId, totalStock: $totalStock)" }
         val key = generateKey(storeId, date)
-        redisTemplate.opsForValue().set(key, totalStock.toString(), Duration.ofHours(TTL_HOURS))
+        stringRedisTemplate.opsForValue().set(key, totalStock.toString(), Duration.ofHours(TTL_HOURS))
     }
 
     override fun getStoreTotalStock(storeId: Long, date: LocalDate): Int? {
         val key = generateKey(storeId, date)
-        return redisTemplate.opsForValue().get(key)?.toIntOrNull()
+        return stringRedisTemplate.opsForValue().get(key)?.toIntOrNull()
     }
 
     override fun deleteStoreTotalStock(storeId: Long, date: LocalDate) {
         val key = generateKey(storeId, date)
-        redisTemplate.delete(key)
+        stringRedisTemplate.delete(key)
     }
 
     private fun generateKey(storeId: Long, date: LocalDate): String {

--- a/eatngo-infra/src/main/kotlin/com/eatngo/redis/repository/subscription/StoreSubscriptionRedisRepositoryImpl.kt
+++ b/eatngo-infra/src/main/kotlin/com/eatngo/redis/repository/subscription/StoreSubscriptionRedisRepositoryImpl.kt
@@ -19,7 +19,7 @@ class StoreSubscriptionRedisRepositoryImpl(
         private const val STORE_SUBSCRIPTION_COUNT_KEY = "store:%d:subscription:count"
         private const val CUSTOMER_SUBSCRIPTION_LIST_KEY = "customer:%d:subscriptions"
         private const val STORE_SUBSCRIPTION_LIST_KEY = "store:%d:subscribers"
-        private const val CACHE_TTL_SECONDS = 60 * 30 // 30분?? TODO: 보통 몇 분으로 설정하는지..?
+        private const val CACHE_TTL_SECONDS = 60 * 30
     }
 
     /**

--- a/eatngo-store-owner-api/src/main/kotlin/com/eatngo/store/docs/request/StoreCreateRequestDocs.kt
+++ b/eatngo-store-owner-api/src/main/kotlin/com/eatngo/store/docs/request/StoreCreateRequestDocs.kt
@@ -122,7 +122,7 @@ interface StoreCreateRequestDocs {
     @get:Schema(
         description = "매장의 대분류 카테고리(리스트로 입력)",
         example = "[\"BREAD\"]",
-        allowableValues = ["BREAD", "BAKERY", "CAFE", "DESSERT", "KOREAN", "FRUIT", "PIZZA", "SALAD", "RICECAKE"],
+        allowableValues = ["BREAD", "CAFE", "KOREAN", "FRUIT", "PIZZA", "SALAD", "RICECAKE", "SANDWICH"],
     )
     val storeCategory: List<String>?
 

--- a/eatngo-store-owner-api/src/main/kotlin/com/eatngo/store/docs/request/StoreUpdateRequestDocs.kt
+++ b/eatngo-store-owner-api/src/main/kotlin/com/eatngo/store/docs/request/StoreUpdateRequestDocs.kt
@@ -106,7 +106,7 @@ interface StoreUpdateRequestDocs {
     @get:Schema(
         description = "매장의 대분류 카테고리(리스트로 입력)",
         example = "[\"BREAD\"]",
-        allowableValues = ["BREAD", "BAKERY", "CAFE", "DESSERT", "KOREAN", "FRUIT", "PIZZA", "SALAD", "RICECAKE"],
+        allowableValues = ["BREAD", "CAFE", "KOREAN", "FRUIT", "PIZZA", "SALAD", "RICECAKE", "SANDWICH"],
     )
     val storeCategory: List<String>?
 

--- a/eatngo-store-owner-api/src/main/kotlin/com/eatngo/store/docs/response/StoreDetailApiResponseDoc.kt
+++ b/eatngo-store-owner-api/src/main/kotlin/com/eatngo/store/docs/response/StoreDetailApiResponseDoc.kt
@@ -6,13 +6,13 @@ import java.time.LocalTime
 
 /** 컨트롤러에서 반환되는 응답 래핑 */
 
-@Schema(description = "매장 상세 응답 예시")
+@Schema(description = "매장 목록 응답 예시")
 data class StoreDetailApiResponseDoc(
     @Schema(description = "요청 성공 여부", example = "true")
     override val success: Boolean = true,
-    @Schema(description = "응답 데이터")
-    override val data: StoreDetailResponseDoc
-) : ApiResponseSuccessDoc<StoreDetailResponseDoc>(success, data)
+    @Schema(description = "매장 목록 데이터")
+    override val data: List<StoreDetailResponseDoc>
+) : ApiResponseSuccessDoc<List<StoreDetailResponseDoc>>(success, data)
 
 /** StoreDetailResponseDoc */
 

--- a/eatngo-store-owner-api/src/main/kotlin/com/eatngo/store/dto/StoreResponse.kt
+++ b/eatngo-store-owner-api/src/main/kotlin/com/eatngo/store/dto/StoreResponse.kt
@@ -11,7 +11,6 @@ data class StoreCUDResponse(val storeId: Long, val actionTime: LocalDateTime? = 
 
 /**
  * 점주가 매장을 관리할 때 상세정보 반환을 위해 사용하는 리스폰스
- * TODO: 추후 백오피스 UI 확정되면 수정 가능성 있음
  */
 data class StoreDetailResponse(
     val id: Long,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,3 +16,4 @@ include(
 include(":eatngo-common:swagger")
 include(":eatngo-common:p6spy")
 include(":eatngo-common:logging")
+include(":eatngo-common:circuit-breaker")


### PR DESCRIPTION
## 🚀 PR 목적 (Goal)
Redis Circuit Breaker 모듈 생성 및 Redis에 totalStockCount 캐싱, 리뷰 데이터 실데이터로 매장에 반영

---

## ✨ 주요 변경 사항 (Changes)
- Redis Circuit Breaker 모듈 추가
- Redis를 활용한 총 재고 수 관리 기능 추가
- 매장 정보에 리뷰 데이터 통합

---

## 📝 상세 설명 (Description)
1. Redis Circuit Breaker
- Redis 연결 실패 시 자동으로 DB로 폴백하는 Circuit Breaker 패턴 구현
- Redis 연결 상태에 따른 자동 복구 메커니즘 추가
- 설정 가능한 임계값과 재시도 정책 적용

2. Redis 재고 관리
- 매장별 총 재고 수를 Redis에 캐싱하여 조회 성능 개선
- 재고 변경 시 Redis 데이터 자동 업데이트
- 캐시 무효화 전략 구현

3. 매장 리뷰 데이터
- 매장 정보에 리뷰 관련 데이터 필드 추가
- 리뷰 집계 정보 반영

---

## #️⃣ 연관 이슈 (Linked Issues)
#117 

---

## 🛠️ 작업 내역 (What was done)
- RedisCircuitBreaker 모듈 구현
- Redis 재고 관리 기능
- 매장 리뷰 데이터 통합

---

## 💬 리뷰 포인트 (Review Points)
- Circuit Breaker 설정값의 적절성
  - 센티널 없이 스탠드얼론이라 fallback시 단계적 성능 저하로 DB 조회하게는 해놨는데 조회 횟수 제한 적절한지
- Redis 재고 데이터 구조 설계의 효율성

---

## ✅ 체크리스트 (Check List)
- [x] 문서/주석 최신화
- [x] 로컬 빌드 및 주요 기능 정상 동작 확인
- [x] Redis 연결 실패 시나리오 테스트

---

## 🗂️ 추가 참고 자료/컨텍스트 (Optional)
- Circuit Breaker 패턴: https://blog.hwahae.co.kr/all/tech/14541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - Redis 기반 서킷 브레이커 기능이 추가되어 장애 상황에서 서비스 안정성을 강화했습니다.
  - 매장별 총 재고 수량을 Redis 및 로컬 캐시에 저장·조회할 수 있는 기능이 추가되었습니다.
  - 매장 상세 및 목록 응답에 리뷰 통계 정보가 포함됩니다.

- **버그 수정**
  - 매장 카테고리에서 "BAKERY", "DESSERT"가 제거되고 "SANDWICH"가 추가되었습니다.

- **문서**
  - 매장 생성/수정 요청 및 상세 응답 예시가 최신 카테고리와 데이터 구조를 반영하도록 수정되었습니다.

- **리팩터**
  - 매장 구독, 재고 관련 로직이 서비스 및 캐시 기반으로 통합되어 성능과 유지보수성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->