### PR TITLE
[FIX] 이벤트를 트랜잭션 커밋 후에 처리하도록 변경(다른 스레드에서 처리하도록 함)

### DIFF
--- a/eatngo-core/src/main/kotlin/com/eatngo/search/event/SearchStoreEventListener.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/search/event/SearchStoreEventListener.kt
@@ -11,6 +11,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
 
 @Component
 class SearchStoreEventListener(
@@ -28,7 +30,7 @@ class SearchStoreEventListener(
      * 검색 시스템에서 매장 정보 변경을 반영하기 위한 메소드
      */
     @Async
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun handleStoreCUDEvent(event: StoreCUDEvent) {
         val rdbStore = searchStorePersistence.syncStore(event.storeId)
         val box =
@@ -68,7 +70,7 @@ class SearchStoreEventListener(
      * 매장 상태 변경 이벤트 처리
      */
     @Async
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun handleStoreStatusChangedEvent(event: StoreStatusChangedEvent) {
         try {
             searchStoreRepository.updateStoreStatus(

--- a/eatngo-core/src/main/kotlin/com/eatngo/search/event/SearchStoreEventListener.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/search/event/SearchStoreEventListener.kt
@@ -8,7 +8,6 @@ import com.eatngo.store.event.StoreCUDEvent
 import com.eatngo.store.event.StoreCUDEventType
 import com.eatngo.store.event.StoreStatusChangedEvent
 import org.slf4j.LoggerFactory
-import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase


### PR DESCRIPTION
## 🚀 PR 목적 (Goal)
매장 CUD 이벤트의 리스너 트랜잭션을 분리

---

## ✨ 주요 변경 사항 (Changes)
매장 CUD 이벤트와 해당 이벤트의 리스너 트랜잭션을 분리함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 이벤트 처리 동작이 트랜잭션 커밋 이후에 실행되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->