### PR TITLE
[FIX] 매장 상세 비로그인 회원/로그인 회원 모두 호출 가능하도록 수정

### DIFF
--- a/eatngo-core/src/main/kotlin/com/eatngo/store/usecase/StoreQueryUseCase.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/store/usecase/StoreQueryUseCase.kt
@@ -21,7 +21,7 @@ class StoreQueryUseCase(
     }
 
     @Transactional(readOnly = true)
-    fun getStoreByIdWithSubscription(storeId: Long, customerId: Long): Pair<StoreDto, Boolean> {
+    fun getStoreByIdWithSubscription(storeId: Long, customerId: Long?): Pair<StoreDto, Boolean> {
         val store = storeService.getStoreById(storeId)
         val reviewStats = storeReviewStatsService.getStoreReviewStats(storeId)
         val storeDto = StoreDto.from(store, reviewStats)

--- a/eatngo-core/src/main/kotlin/com/eatngo/subscription/infra/StoreSubscriptionPersistence.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/subscription/infra/StoreSubscriptionPersistence.kt
@@ -26,7 +26,7 @@ interface StoreSubscriptionPersistence {
     /**
      * 사용자 ID와 상점 ID로 상점 구독 조회 - deleted 된 것도 전부 조회
      */
-    fun findAllByUserIdAndStoreId(userId: Long, storeId: Long): StoreSubscription?
+    fun findAllByUserIdAndStoreId(userId: Long?, storeId: Long): StoreSubscription?
 
     /**
      * 상점 구독 저장

--- a/eatngo-core/src/main/kotlin/com/eatngo/subscription/service/StoreSubscriptionService.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/subscription/service/StoreSubscriptionService.kt
@@ -22,7 +22,7 @@ interface StoreSubscriptionService {
     /**
      * 사용자가 매장을 구독하고 있는지 확인
      */
-    fun isSubscribed(storeId: Long, customerId: Long): Boolean
+    fun isSubscribed(storeId: Long, customerId: Long?): Boolean
 
     /**
      * 사용자가 구독하고 있는 매장 ID 목록 조회 (활성 구독만)

--- a/eatngo-core/src/main/kotlin/com/eatngo/subscription/service/impl/StoreSubscriptionServiceImpl.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/subscription/service/impl/StoreSubscriptionServiceImpl.kt
@@ -116,15 +116,8 @@ class StoreSubscriptionServiceImpl(
     }
 
     override fun isSubscribed(storeId: Long, customerId: Long?): Boolean {
-        if (customerId == null) {
-            println("DEBUG: customerId is null, returning false")
-            return false
-        }
-        println("DEBUG: customerId=$customerId, storeId=$storeId")
         val subscription = storeSubscriptionPersistence.findAllByUserIdAndStoreId(customerId, storeId)
-        val isActive = subscription?.isActive() == true
-        println("DEBUG: subscription=$subscription, isActive=$isActive")
-        return isActive
+        return subscription?.isActive() == true
     }
 
     override fun getSubscribedStoreIds(customerId: Long): List<Long> {

--- a/eatngo-core/src/main/kotlin/com/eatngo/subscription/service/impl/StoreSubscriptionServiceImpl.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/subscription/service/impl/StoreSubscriptionServiceImpl.kt
@@ -115,9 +115,16 @@ class StoreSubscriptionServiceImpl(
         return Cursor.from(subscriptionDtos, cursoredSubscriptions.lastId)
     }
 
-    override fun isSubscribed(storeId: Long, customerId: Long): Boolean {
+    override fun isSubscribed(storeId: Long, customerId: Long?): Boolean {
+        if (customerId == null) {
+            println("DEBUG: customerId is null, returning false")
+            return false
+        }
+        println("DEBUG: customerId=$customerId, storeId=$storeId")
         val subscription = storeSubscriptionPersistence.findAllByUserIdAndStoreId(customerId, storeId)
-        return subscription?.isActive() == true
+        val isActive = subscription?.isActive() == true
+        println("DEBUG: subscription=$subscription, isActive=$isActive")
+        return isActive
     }
 
     override fun getSubscribedStoreIds(customerId: Long): List<Long> {

--- a/eatngo-customer-api/src/main/kotlin/com/eatngo/auth/resolver/CustomerIdArgumentResolver.kt
+++ b/eatngo-customer-api/src/main/kotlin/com/eatngo/auth/resolver/CustomerIdArgumentResolver.kt
@@ -14,7 +14,7 @@ import org.springframework.web.method.support.ModelAndViewContainer
 class CustomerIdArgumentResolver : HandlerMethodArgumentResolver {
     override fun supportsParameter(parameter: MethodParameter): Boolean {
         return parameter.hasParameterAnnotation(CustomerId::class.java)
-                && (parameter.parameterType == Long::class.java || parameter.parameterType == Long::class.javaObjectType)
+                && parameter.parameterType == Long::class.javaObjectType
     }
 
     override fun resolveArgument(
@@ -26,13 +26,10 @@ class CustomerIdArgumentResolver : HandlerMethodArgumentResolver {
         val authentication = SecurityContextHolder.getContext().authentication
         val principal = authentication?.principal
 
-        val result = when (principal) {
+        return when (principal) {
             is String -> if (principal == "anonymousUser") null else principal.toLongOrNull()
             is LoginCustomer -> principal.customerId
             else -> null
         }
-        
-        println("DEBUG: CustomerIdArgumentResolver - principal=$principal, result=$result")
-        return result
     }
 }

--- a/eatngo-customer-api/src/main/kotlin/com/eatngo/auth/resolver/CustomerIdArgumentResolver.kt
+++ b/eatngo-customer-api/src/main/kotlin/com/eatngo/auth/resolver/CustomerIdArgumentResolver.kt
@@ -14,7 +14,7 @@ import org.springframework.web.method.support.ModelAndViewContainer
 class CustomerIdArgumentResolver : HandlerMethodArgumentResolver {
     override fun supportsParameter(parameter: MethodParameter): Boolean {
         return parameter.hasParameterAnnotation(CustomerId::class.java)
-                && parameter.parameterType == Long::class.java
+                && (parameter.parameterType == Long::class.java || parameter.parameterType == Long::class.javaObjectType)
     }
 
     override fun resolveArgument(
@@ -26,10 +26,13 @@ class CustomerIdArgumentResolver : HandlerMethodArgumentResolver {
         val authentication = SecurityContextHolder.getContext().authentication
         val principal = authentication?.principal
 
-        return when (principal) {
+        val result = when (principal) {
             is String -> if (principal == "anonymousUser") null else principal.toLongOrNull()
             is LoginCustomer -> principal.customerId
             else -> null
         }
+        
+        println("DEBUG: CustomerIdArgumentResolver - principal=$principal, result=$result")
+        return result
     }
 }

--- a/eatngo-customer-api/src/main/kotlin/com/eatngo/store/controller/StoreController.kt
+++ b/eatngo-customer-api/src/main/kotlin/com/eatngo/store/controller/StoreController.kt
@@ -16,7 +16,7 @@ class StoreController(
     private val storeQueryUseCase: StoreQueryUseCase
 ) : StoreCustomerControllerDocs {
     @GetMapping("/{storeId}")
-    override fun getStoreById(@PathVariable storeId: Long, @CustomerId customerId: Long): ApiResponse<StoreDetailResponse> {
+    override fun getStoreById(@PathVariable storeId: Long, @CustomerId customerId: Long?): ApiResponse<StoreDetailResponse> {
         val (storeDto, isFavorite) = storeQueryUseCase.getStoreByIdWithSubscription(storeId, customerId)
         val response = StoreDetailResponse.from(storeDto, isFavorite)
         return ApiResponse.success(response)

--- a/eatngo-customer-api/src/main/kotlin/com/eatngo/store/docs/controller/StoreCustomerControllerDocs.kt
+++ b/eatngo-customer-api/src/main/kotlin/com/eatngo/store/docs/controller/StoreCustomerControllerDocs.kt
@@ -36,7 +36,7 @@ interface StoreCustomerControllerDocs {
     fun getStoreById(
         @Parameter(description = "조회할 매장 ID", required = true)
         @PathVariable storeId: Long,
-        @Parameter(description = "고객 ID", hidden = true)
-        customerId: Long
+        @Parameter(description = "고객 ID", required = false, hidden = true)
+        customerId: Long?
     ): com.eatngo.common.response.ApiResponse<StoreDetailResponse>
 }

--- a/eatngo-infra/src/main/kotlin/com/eatngo/subscription/persistence/StoreSubscriptionPersistenceImpl.kt
+++ b/eatngo-infra/src/main/kotlin/com/eatngo/subscription/persistence/StoreSubscriptionPersistenceImpl.kt
@@ -35,7 +35,7 @@ class StoreSubscriptionPersistenceImpl(
             .map { StoreSubscriptionJpaEntity.toSubscription(it) }
     }
 
-    override fun findAllByUserIdAndStoreId(userId: Long, storeId: Long): StoreSubscription? {
+    override fun findAllByUserIdAndStoreId(userId: Long?, storeId: Long): StoreSubscription? {
         return storeSubscriptionRdbRepository.findByUserIdAndStoreId(userId, storeId)
             ?.let { StoreSubscriptionJpaEntity.toSubscription(it) }
     }

--- a/eatngo-infra/src/main/kotlin/com/eatngo/subscription/rdb/repository/StoreSubscriptionJpaRepository.kt
+++ b/eatngo-infra/src/main/kotlin/com/eatngo/subscription/rdb/repository/StoreSubscriptionJpaRepository.kt
@@ -26,7 +26,7 @@ interface StoreSubscriptionJpaRepository : JpaRepository<StoreSubscriptionJpaEnt
     /**
      * 사용자 ID와 매장 ID로 구독 조회
      */
-    fun findByUserIdAndStoreId(userId: Long, storeId: Long): StoreSubscriptionJpaEntity?
+    fun findByUserIdAndStoreId(userId: Long?, storeId: Long): StoreSubscriptionJpaEntity?
 
     /**
      * 사용자 ID와 매장 ID로 구독 존재 여부 확인


### PR DESCRIPTION
## 🚀 PR 목적 (Goal)
매장 상세 비로그인 회원/로그인 회원 모두 호출 가능하도록 수정
---

## ✨ 주요 변경 사항 (Changes)
isFavorite를 포함해 비로그인 회원/로그인 회원 모두 조회 가능하도록 버그 수정
