### PR TITLE
[FIX] 무한스크롤 버그 수정

### DIFF
--- a/eatngo-infra/src/main/kotlin/com/eatngo/subscription/persistence/StoreSubscriptionPersistenceImpl.kt
+++ b/eatngo-infra/src/main/kotlin/com/eatngo/subscription/persistence/StoreSubscriptionPersistenceImpl.kt
@@ -76,10 +76,16 @@ class StoreSubscriptionPersistenceImpl(
             else -> throw IllegalArgumentException("지원하지 않는 쿼리 파라미터 타입입니다: ${queryParam::class.simpleName}")
         }
 
+        val nextLastId = if (cursoredSubscriptionJpaEntities.hasNext()) {
+            cursoredSubscriptionJpaEntities.content.lastOrNull()?.id
+        } else {
+            null
+        }
+
         return Cursor.from(
             cursoredSubscriptionJpaEntities.content
                 .map(StoreSubscriptionJpaEntity::toSubscription),
-            cursoredSubscriptionJpaEntities.lastOrNull()?.id
+            nextLastId
         )
     }
 } 


### PR DESCRIPTION
## 🚀 PR 목적 (Goal)
 무한스크롤 버그 수정

---

## ✨ 주요 변경 사항 (Changes)
lastId가 null로 나와야 하는데 나오지 않는 문제 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터링**
  - 구독 조회 시 쿼리 파라미터 타입별로 데이터 처리 흐름이 명확하게 개선되었습니다.
  - 고객 구독 목록 조회 시 매장 재고 정보를 일괄 조회하여 성능이 향상되었습니다.
  - 구독 목록 페이지네이션 처리에서 다음 페이지가 없을 경우 커서 값이 null로 반환되어, 페이지네이션 동작이 더 직관적으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->