### PR TITLE
fix: OrderListCount 를 50에서 10으로 변경, last id 로직 수정

### DIFF
--- a/eatngo-infra/src/main/kotlin/com/eatngo/order/persistence/OrderPersistenceImpl.kt
+++ b/eatngo-infra/src/main/kotlin/com/eatngo/order/persistence/OrderPersistenceImpl.kt
@@ -31,7 +31,7 @@ class OrderPersistenceImpl(
             .mapOrNull(OrderJpaEntity::toOrder)
 
     override fun findAllByQueryParameter(queryParam: OrderQueryParamDto): Cursor<Order> {
-        val pageRequest = PageRequest.of(0, 50, Sort.by("id").descending())
+        val pageRequest = PageRequest.of(0, 10, Sort.by("id").descending())
 
         val cursoredOrderJpaEntities =
             getCursoredOrderJpaEntities(queryParam, pageRequest)
@@ -39,7 +39,7 @@ class OrderPersistenceImpl(
         return Cursor.from(
             cursoredOrderJpaEntities.content
                 .map(OrderJpaEntity::toOrder),
-            cursoredOrderJpaEntities.lastOrNull()?.id,
+            if (cursoredOrderJpaEntities.hasNext()) cursoredOrderJpaEntities.lastOrNull()?.id else null,
         )
     }
 


### PR DESCRIPTION
## 🚀 PR 목적 (Goal)
<!-- 이 PR이 해결하려는 문제/목표를 한 문장으로 명확하게 작성해주세요. -->

---

## ✨ 주요 변경 사항 (Changes)
<!--
- 코드/구조/의존성 등 핵심 변경점만 요약
- ex) 주문 생성 API 추가, User 도메인 리팩토링, 결제 모듈 외부 API 연동 등
-->

---

## 📝 상세 설명 (Description)
<!--
- 구현 방식, 고민한 점, 선택한 대안
- 기존과 달라진 동작, 예외 처리 등
- 리뷰어가 이해를 위해 미리 알면 좋은 내용
-->

---

## #️⃣ 연관 이슈 (Linked Issues)
<!-- ex) #123, #456 -->

---

## 🛠️ 작업 내역 (What was done)
<!--
- 이번 PR에서 실제로 작업한 내용을 항목별로 정리
- UI/UX 변경, API 추가/수정, 테스트 코드 작성 등
- 이미지/스크린샷 첨부 가능
-->

---

### 📸 스크린샷/데모 (선택, Screenshots/Demo)
<!-- UI 변경, API 응답 예시 등 시각적 자료가 있다면 첨부 -->

---

## 💬 리뷰 포인트 (Review Points)
<!--
- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 궁금한 점, 네이밍/구현 관련 의견 요청 등
- ex) "이 함수 네이밍이 적절한지?", "트랜잭션 처리 방식이 괜찮은지?"
-->

---

## ✅ 체크리스트 (Check List)
- [ ] 테스트 코드 작성 및 통과
- [ ] 문서/주석 최신화
- [ ] 로컬 빌드 및 주요 기능 정상 동작 확인
- [ ] 기타(아래에 추가)

---

## 🗂️ 추가 참고 자료/컨텍스트 (Optional)
<!--
- 참고한 문서, 외부 레퍼런스, 관련 이슈/PR 링크 등
- 기타 전달하고 싶은 내용
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 주문 목록 조회 시 페이지 크기가 50에서 10으로 축소되어 한 번에 더 적은 수의 주문이 표시됩니다.
  - 다음 페이지 토큰이 실제로 다음 페이지가 있을 때만 제공되어, 더 이상 데이터가 없을 경우 불필요한 토큰이 표시되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->