### PR TITLE
[FEAT] 버그 바운티 위한 매장 상태 변경/매장 생성 시 검증 로직 추가 구현

### DIFF
--- a/eatngo-core/src/main/kotlin/com/eatngo/common/error/BusinessErrorCode.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/common/error/BusinessErrorCode.kt
@@ -103,5 +103,6 @@ enum class BusinessErrorCode(
     STOCK_EMPTY("ST002", "상품의 재고가 없습니다.", 409),
     INVENTORY_NOT_FOUND("I001", "상품 재고를 찾을 수 없습니다.", 400),
     STORE_TOTAL_STOCK_QUERY_FAILED("ST003", "매장 총 재고 조회에 실패했습니다.", 500),
+    STORE_CANNOT_OPEN_NO_STOCK("ST004", "재고가 없어 매장을 오픈할 수 없습니다.", 409),
 
 }

--- a/eatngo-core/src/main/kotlin/com/eatngo/common/error/BusinessErrorCode.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/common/error/BusinessErrorCode.kt
@@ -78,6 +78,9 @@ enum class BusinessErrorCode(
     // 매장 스케줄러 관련 오류
     STORE_BATCH_UPDATE_FAILED("S017", "매장 상태 배치 업데이트에 실패했습니다.", 500),
 
+    // 점주당 매장 개수 제한 오류
+    STORE_OWNER_LIMIT_EXCEEDED("S018", "점주당 매장 등록 개수 제한을 초과했습니다.", 409),
+
     // 메뉴 관련 오류
     PRODUCT_NOT_FOUND("M001", "메뉴를 찾을 수 없습니다.", 404),
     PRODUCT_NOT_AVAILABLE("M002", "현재 제공하지 않는 메뉴입니다.", 409),

--- a/eatngo-core/src/main/kotlin/com/eatngo/common/exception/store/StoreException.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/common/exception/store/StoreException.kt
@@ -83,4 +83,14 @@ open class StoreException(
         cause = cause,
         logLevel = Level.WARN
     )
+
+    class StoreCannotOpenNoStock(
+        storeId: Long,
+        totalStock: Int
+    ) : StoreException(
+        errorCode = BusinessErrorCode.STORE_CANNOT_OPEN_NO_STOCK,
+        message = "${BusinessErrorCode.STORE_CANNOT_OPEN_NO_STOCK.message}: storeId=$storeId, totalStock=$totalStock",
+        data = mapOf("storeId" to storeId, "totalStock" to totalStock),
+        logLevel = Level.WARN
+    )
 }

--- a/eatngo-core/src/main/kotlin/com/eatngo/common/exception/store/StoreException.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/common/exception/store/StoreException.kt
@@ -93,4 +93,19 @@ open class StoreException(
         data = mapOf("storeId" to storeId, "totalStock" to totalStock),
         logLevel = Level.WARN
     )
+
+    class StoreOwnerLimitExceeded(
+        storeOwnerId: Long,
+        currentStoreCount: Int,
+        maxAllowedStores: Int
+    ) : StoreException(
+        errorCode = BusinessErrorCode.STORE_OWNER_LIMIT_EXCEEDED,
+        message = "${BusinessErrorCode.STORE_OWNER_LIMIT_EXCEEDED.message} (최대 ${maxAllowedStores}개, 현재 ${currentStoreCount}개): storeOwnerId=$storeOwnerId",
+        data = mapOf(
+            "storeOwnerId" to storeOwnerId, 
+            "currentStoreCount" to currentStoreCount,
+            "maxAllowedStores" to maxAllowedStores
+        ),
+        logLevel = Level.WARN
+    )
 }

--- a/eatngo-core/src/main/kotlin/com/eatngo/store/service/impl/StoreServiceImpl.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/store/service/impl/StoreServiceImpl.kt
@@ -56,8 +56,6 @@ class StoreServiceImpl(
         storeOwnerId: Long?,
     ): Store {
         val existingStore = storePersistence.findById(id).orThrow { StoreException.StoreNotFound(id) }
-        // 점주가 직접 변경하는 경우에만 권한 확인
-        storeOwnerId?.let { existingStore.requireOwner(it) }
 
         when (newStatus) {
             StoreEnum.StoreStatus.OPEN -> existingStore.toOpen()

--- a/eatngo-core/src/main/kotlin/com/eatngo/store/usecase/StoreOwnerStatusChangedUseCase.kt
+++ b/eatngo-core/src/main/kotlin/com/eatngo/store/usecase/StoreOwnerStatusChangedUseCase.kt
@@ -1,23 +1,31 @@
 package com.eatngo.store.usecase
 
 import com.eatngo.common.constant.StoreEnum
+import com.eatngo.common.exception.store.StoreException
 import com.eatngo.store.dto.StoreDto
 import com.eatngo.store.event.StoreStatusChangedEvent
+import com.eatngo.store.infra.StoreTotalStockRedisRepository
 import com.eatngo.store.service.StoreService
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 
 @Service
 class StoreOwnerStatusChangeUseCase(
     private val storeService: StoreService,
-    private val eventPublisher: ApplicationEventPublisher
+    private val eventPublisher: ApplicationEventPublisher,
+    private val storeTotalStockRedisRepository: StoreTotalStockRedisRepository
 ) {
     @Transactional
     fun change(storeId: Long, storeOwnerId: Long, status: StoreEnum.StoreStatus): StoreDto {
         val store = storeService.getStoreById(storeId)
         val previousStatus = store.status
-        
+        //권한확인
+        store.requireOwner(storeOwnerId)
+        //오픈 변경 전 재고부터 확인
+        if (status == StoreEnum.StoreStatus.OPEN) validateStockForOpen(storeId)
+
         val updatedStore = storeService.updateStoreStatus(storeId, status, storeOwnerId)
 
         if (updatedStore.status != previousStatus) {
@@ -33,5 +41,19 @@ class StoreOwnerStatusChangeUseCase(
         }
 
         return StoreDto.from(updatedStore)
+    }
+    
+    /**
+     * 매장 오픈을 위한 재고 검증
+     * Redis에서 오늘 날짜의 총 재고를 조회하여 확인
+     */
+    private fun validateStockForOpen(storeId: Long) {
+        val today = LocalDate.now()
+        val totalStock = storeTotalStockRedisRepository.getStoreTotalStock(storeId, today)
+        
+        // totalStock이 null(-1)이거나 0인 경우 오픈 불가
+        if (totalStock == null || totalStock <= 0) {
+            throw StoreException.StoreCannotOpenNoStock(storeId, totalStock ?: -1)
+        }
     }
 }

--- a/eatngo-store-owner-api/src/main/kotlin/com/eatngo/store/docs/controller/StoreOwnerControllerDocs.kt
+++ b/eatngo-store-owner-api/src/main/kotlin/com/eatngo/store/docs/controller/StoreOwnerControllerDocs.kt
@@ -43,7 +43,7 @@ interface StoreOwnerControllerDocs {
 
     @Operation(
         summary = "매장 등록",
-        description = "새로운 매장을 등록합니다. 매장 등록 시 필수 정보와 선택 정보를 입력받습니다."
+        description = "새로운 매장을 등록합니다. 매장 등록 시 필수 정보와 선택 정보를 입력받습니다.(매장은 점주 ID당 1개씩만 등록 가능합니다.)"
     )
     @ApiResponses(
         value = [
@@ -96,7 +96,12 @@ interface StoreOwnerControllerDocs {
 
     @Operation(
         summary = "매장 상태 변경",
-        description = "매장의 영업 상태를 변경합니다. (OPEN: 영업중, CLOSED: 영업종료, PENDING: 승인대기)"
+        description = """
+           매장의 영업 상태를 변경합니다.
+           [OPEN: 영업중, CLOSED: 영업종료, PENDING: 승인대기] 중
+           점주는 [OPEN: 영업중] 또는 [CLOSED: 영업종료]로만 변경 가능하며,
+           재고가 1개도 없는 상태에서는 닫힌 매장의 상태를 OPEN 할 수 없습니다.
+        """
     )
     @ApiResponses(
         value = [


### PR DESCRIPTION
## 🚀 PR 목적 (Goal)
매장 상태 변경 시 재고 검증 로직 추가 및 점주당 매장 1개 제한 기능 구현

---

## ✨ 주요 변경 사항 (Changes)
- 매장 OPEN 상태 변경 시 Redis 재고 확인 validation 추가
- 점주당 매장 등록 개수 1개 제한 기능 추가
- 매장 상태 변경 로직에서 권한 확인 순서 개선
- 관련 예외 처리 및 에러 코드 추가

---

## 📝 상세 설명 (Description)
### 1. 매장 재고 검증 로직
- 점주가 매장을 OPEN 상태로 변경하려 할 때 Redis에서 당일 총 재고를 확인
- 재고가 0이거나 데이터가 없는 경우(-1) 매장 오픈을 차단

### 2. 점주당 매장 1개 제한
- 현재 비즈니스 요구사항에 따라 점주당 매장 1개만 등록 가능하도록 제한
- 추후 다중 매장 지원 시 상수 값만 변경하면 되도록 확장성 고려
- 매장 생성 시점에 기존 매장 존재 여부 검증

### 3. 권한 확인 순서 개선
- 기존: Service Layer에서 권한 확인
- 개선: UseCase에서 권한 → 재고 → 상태변경 순서로 비즈니스 로직 제어
- 권한이 없는 사용자에게 재고 정보 노출 방지

---

## #️⃣ 연관 이슈 (Linked Issues)
생략

---

## 🛠️ 작업 내역 (What was done)
- **에러 코드 추가**
  - `STORE_CANNOT_OPEN_NO_STOCK`: 재고 부족으로 매장 오픈 불가
  - `STORE_OWNER_LIMIT_EXCEEDED`: 점주당 매장 개수 제한 초과

- **예외 클래스 추가**
  - `StoreCannotOpenNoStock`: 재고 부족 예외
  - `StoreOwnerLimitExceeded`: 매장 개수 제한 예외

- **비즈니스 로직 구현**
  - `StoreOwnerStatusChangeUseCase`: 재고 검증 로직 추가
  - `StoreCUDUseCase`: 매장 개수 제한 검증 로직 추가
  - `StoreServiceImpl`: 중복 권한 확인 로직 제거

### 상세 구현사항
1. **재고 검증 플로우**
   ```
   권한 확인 → 재고 확인 → 상태 변경 → 이벤트 발행
   ```

2. **매장 생성 플로우**
   ```
   매장 개수 확인 → 매장 생성 → 이벤트 발행
   ```

3. **에러 응답 예시**
   ```json
   {
     "success": false,
     "errorCode": "ST004",
     "errorMessage": "재고가 없어 매장을 오픈할 수 없습니다.: storeId=7, totalStock=-1"
   }
   ```

---

## 💬 리뷰 포인트 (Review Points)
생략

---

## ✅ 체크리스트 (Check List)
- [x] 문서/주석 최신화
- [x] 로컬 빌드 및 주요 기능 정상 동작 확인
- [x] 기존 매장 상태 변경 로직 호환성 검증
- [x] 에러 메시지 및 HTTP 상태 코드 적절성 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 점주당 매장 등록 개수 제한(1개) 및 재고가 없을 시 매장 오픈 불가 기능이 추가되었습니다.
- **버그 수정**
    - 매장 상태 변경 시 재고가 없으면 오픈할 수 없도록 검증이 추가되었습니다.
- **문서**
    - 매장 등록 및 상태 변경 API 문서에 점주당 1개 매장 제한 및 재고 조건 관련 설명이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->